### PR TITLE
add missing 0x to RGT to be in line with pattern (and hopefully fix Uniswap app)

### DIFF
--- a/optimism.tokenlist.json
+++ b/optimism.tokenlist.json
@@ -387,7 +387,7 @@
     },
     {
       "chainId": 10,
-      "address": "b548f63d4405466b36c0c0ac3318a22fdcec711a",
+      "address": "0xb548f63d4405466b36c0c0ac3318a22fdcec711a",
       "name": "Rari Governance Token",
       "symbol": "RGT",
       "decimals": 18,

--- a/optimism.tokenlist.json
+++ b/optimism.tokenlist.json
@@ -400,6 +400,6 @@
   "version": {
     "major": 3,
     "minor": 1,
-    "patch": 0
+    "patch": 1
   }
 }


### PR DESCRIPTION
I think this is causing missing tokens on Uniswap app.

![image](https://user-images.githubusercontent.com/40821065/129979928-2d6a7686-80d2-4a1c-950b-e4eef86939e9.png)

![image](https://user-images.githubusercontent.com/40821065/129979948-4897950e-282c-49cd-a6b0-04149340baeb.png)
