### PR TITLE
Add sUSD and bridge addresses for all networks

### DIFF
--- a/optimism.tokenlist.json
+++ b/optimism.tokenlist.json
@@ -313,12 +313,15 @@
       }
     },
     {
-      "chainId": 69,
-      "address": "0xaA5068dC2B3AADE533d3e52C6eeaadC6a8154c57",
+      "chainId": 1,
+      "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
       "name": "Synthetix USD",
       "symbol": "sUSD",
       "decimals": 18,
-      "logoURI": "https://ethereum-optimism.github.io/logos/sUSD.svg"
+      "logoURI": "https://ethereum-optimism.github.io/logos/sUSD.svg",
+      "extensions": {
+        "optimismBridgeAddress": "0x39Ea01a0298C315d149a490E34B59Dbf2EC7e48F"
+      }
     },
     {
       "chainId": 10,
@@ -326,7 +329,32 @@
       "name": "Synthetix USD",
       "symbol": "sUSD",
       "decimals": 18,
-      "logoURI": "https://ethereum-optimism.github.io/logos/sUSD.svg"
+      "logoURI": "https://ethereum-optimism.github.io/logos/sUSD.svg",
+      "extensions": {
+        "optimismBridgeAddress": "0x136b1EC699c62b0606854056f02dC7Bb80482d63"
+      }
+    },
+    {
+      "chainId": 42,
+      "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
+      "name": "Synthetix USD",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/logos/sUSD.svg",
+      "extensions": {
+        "optimismBridgeAddress": "0xc00E7C2Bd7B0Fb95DbBF10d2d336399A939099ee"
+      }
+    },
+    {
+      "chainId": 69,
+      "address": "0xaA5068dC2B3AADE533d3e52C6eeaadC6a8154c57",
+      "name": "Synthetix USD",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/logos/sUSD.svg",
+      "extensions": {
+        "optimismBridgeAddress": "0x5b643DFC67f9701929A0b55f23e0Af61df50E75D"
+      }
     },
     {
       "chainId": 42,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
We added functionality to transfer `sUSD` across layers using the Synthetix bridges. 

**Additional context**
While the same bridge contracts are used for the SNX token, the synth transfers utilize different methods: 

- `initiateSynthTransfer`
  - https://github.com/Synthetixio/synthetix/blob/4d2add4f74c68ac4f1106f6e7be4c31d4f1ccc76/contracts/BaseSynthetixBridge.sol#L149 
  
- `finalizeSynthTransfer`
  - https://github.com/Synthetixio/synthetix/blob/4d2add4f74c68ac4f1106f6e7be4c31d4f1ccc76/contracts/BaseSynthetixBridge.sol#L177


