### PR TITLE
chore: Log error in catch block

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -144,7 +144,8 @@ const validateBridgeAddress = async currentChainTokenData => {
           `Bridge address invalid for ${currentChainTokenData.symbol}: ${currentChainTokenData.extensions.optimismBridgeAddress}`
         );
       }
-    } catch {
+    } catch(e) {
+      console.error(e)
       throw Error(
         `Bridge validation error for ${currentChainTokenData.symbol}`
       );


### PR DESCRIPTION
Make it easier to debug when validation fails by logging an error in a catch block