### PR TITLE
feat(ci): correct validate.yml perms

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+
     strategy:
       matrix:
         node-version: [16.x]


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Gives validate.yml the correct permissions to comment on PRs when PRs
are made by external contributors.
