### PR TITLE
fix(ci): make PR comments work for forks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,7 +3,7 @@ name: Validate PR
 on:
   push:
     branches: [master]
-  pull_request:
+  pull_request_target:
     branches: [master]
 
 jobs:
@@ -20,6 +20,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Be careful! We need this action to be able to make comments on PRs from external repos, but
+      # doing so requires using the pull_request_target workflow trigger. Using this trigger will
+      # run the workflow in the context of the base branch, not the remote branch, which gives the
+      # workflow access to secrets. You MUST NOT clone any remote code to execute here. Since we're
+      # only cloning data files and these files are never executed (only parsed), this step is OK.
+      - name: Checkout remote data files
+        run: |
+          if [ ${{ github.event_name }} == "pull_request_target" ]; then
+            git remote add pr ${{ github.event.pull_request.head.repo.clone_url }}
+            git fetch pr
+            git checkout pr/${{ github.event.pull_request.head.ref }} -- data/
+
+            if [ ${{ github.event.pull_request.head.repo.fork }} == "true" ]; then
+              if git diff --name-only --cached | grep -vE '(data.json|logo.svg|logo.png)$'; then
+                echo "external PRs can only contain data.json or logo files" > err.log
+              fi
+            fi
+          fi
+      
       - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
@@ -40,13 +59,9 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v27
-
       - name: Validate token list
         run: |
-          npm run validate ${{ steps.changed-files.outputs.all_changed_files }} 2> err.out 1> log.out
+          npm run validate $(git diff --name-only --cached) 2> err.out 1> log.out
 
       - name: Read log message
         id: log-message


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates CI so PR comments properly work for forks. Requires that we use
pull_request_target with some hacky code. Please review carefully and
think of potential ways in which the external clone could be exploited.