### PR TITLE
Add Goerli WBTC

### DIFF
--- a/data/WBTC/data.json
+++ b/data/WBTC/data.json
@@ -14,6 +14,12 @@
     },
     "optimism-kovan": {
       "address": "0x2382a8f65b9120E554d1836a504808aC864E169d"
+    },
+    "goerli": {
+      "address": "0xC04B0d3107736C32e19F1c62b2aF67BE61d63a05"
+    },
+    "optimism-goerli": {
+      "address": "0xe0a592353e81a94Db6E3226fD4A99F881751776a"
     }
   }
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Add Goerli addresses to WBTC

L1 https://goerli.etherscan.io/address/0xC04B0d3107736C32e19F1c62b2aF67BE61d63a05 (There isn't an official WBTC testnet token, but this one is used by Compound as has Uniswap liquidity)
L2 https://blockscout.com/optimism/goerli/address/0xe0a592353e81a94Db6E3226fD4A99F881751776a (I just deployed this) 

**Additional context**

**Metadata**
- Fixes https://linear.app/optimism/issue/ENG-2542/redeploy-standard-tokens-update-tokenlist
