### PR TITLE
fix(ci): always pass tokens parameter

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,8 +62,8 @@ jobs:
 
       - name: Validate token list
         run: |
-          CHANGED=$(git diff --name-only | sed -nr "s/data\/(.*?)\/.*/\1/p" | paste -sd "," -)
-          node ./bin/cli.js validate --datadir ./data --tokens ${CHANGED} 2> err.out 1> std.out
+          CHANGED=$(git diff --name-only --cached | sed -nr "s/data\/(.*?)\/.*/\1/p" | paste -sd "," -)
+          node ./bin/cli.js validate --datadir ./data --tokens "${CHANGED}" 2> err.out 1> std.out
 
       - name: Read log message
         id: log-message


### PR DESCRIPTION

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
One last CI fix, always pass the --tokens parameter by quoting.
