### PR TITLE
Add Goerli USDT

### DIFF
--- a/data/USDT/data.json
+++ b/data/USDT/data.json
@@ -2,6 +2,9 @@
   "name": "Tether USD",
   "symbol": "USDT",
   "decimals": 6,
+  "description": "Bringing real world currency to the blockchain.",
+  "website": "https://tether.to/",
+  "twitter": "@Tether_to",
   "tokens": {
     "ethereum": {
       "address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
@@ -14,6 +17,12 @@
     },
     "optimism-kovan": {
       "address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607"
+    },
+    "goerli": {
+      "address": "0xC2C527C0CACF457746Bd31B2a698Fe89de2b6d49"
+    },
+    "optimism-goerli": {
+      "address": "0x853eb4bA5D0Ba2B77a0A5329Fd2110d5CE149ECE"
     }
   }
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adding Goerli USDT addresses

L1 https://goerli.etherscan.io/token/0xc2c527c0cacf457746bd31b2a698fe89de2b6d49 there isn't an official USDT testnet token, so I picked this one that has SOME uniswap liquidity and the most holders
L2 https://goerli-optimism.etherscan.io/address/0x853eb4ba5d0ba2b77a0a5329fd2110d5ce149ece (just deployed this) 

**Tests**

**Additional context**

**Metadata**
- Fixes https://linear.app/optimism/issue/ENG-2542/redeploy-standard-tokens-update-tokenlist
