### PR TITLE
fix(ci): always upload artifacts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,7 +42,6 @@ jobs:
           node ./bin/cli.js validate --datadir ./data --tokens "${CHANGED}" 2> err.out 1> std.out
 
       - name: Upload artifacts
-        if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: logs-artifact


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes the validation step to always upload artifacts instead of just on error.