### PR TITLE
fix(ci): have CI record PR numbers

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
+      - name: Save PR number
+        run: echo ${{ github.event.number }} > pr.txt
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v29
@@ -54,5 +57,6 @@ jobs:
         with:
           name: logs-artifact
           path: |
-            err.out
-            std.out
+            pr.txt
+            err.txt
+            std.txt


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Has CI record PR numbers in artifacts. For whatever reason, GitHub does not make it easy to figure out which PR triggered a given workflow. Recording the PR number as an artifact is an easy hack that makes it possible for external bots to access this information.