### PR TITLE
feat: add Flashstake bridge info

### DIFF
--- a/data/FLASH/data.json
+++ b/data/FLASH/data.json
@@ -1,0 +1,16 @@
+{
+  "name": "Flashstake",
+  "symbol": "FLASH",
+  "decimals": 18,
+  "description": "Flashstake protocol is a financial infrastructure allowing users to receive instant yield on deposits by locking up principal for a chosen duration.",
+  "website": "https://flashstake.io",
+  "twitter": "@Flashstake",
+  "tokens": {
+    "ethereum": {
+      "address": "0xB1f1F47061A7Be15C69f378CB3f69423bD58F2F8"
+    },
+    "optimism": {
+      "address": "0x86bEA60374f220dE9769b2fEf2db725bc1cDd335"
+    }
+  }
+}

--- a/data/FLASH/logo.svg
+++ b/data/FLASH/logo.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Camada_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 3000 3000" style="enable-background:new 0 0 3000 3000;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:#FFFFFF;}
+</style>
+<g>
+	<circle cx="1500" cy="1500" r="1500"/>
+	
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="728.3016" y1="-729.7038" x2="3728.2993" y2="-729.7038" gradientTransform="matrix(0.7071 -0.7071 0.7071 0.7071 440.3318 3591.6245)">
+		<stop  offset="0" style="stop-color:#00F9FF"/>
+		<stop  offset="1" style="stop-color:#FF0095"/>
+	</linearGradient>
+	<path class="st0" d="M439.3,439.3c-585.8,585.8-585.8,1535.5,0,2121.3s1535.5,585.8,2121.3,0c585.8-585.8,585.8-1535.5,0-2121.3
+		S1025.1-146.4,439.3,439.3z M2475.9,2475.9c-538.1,538.1-1413.6,538.1-1951.7,0s-538.1-1413.6,0-1951.7s1413.6-538.1,1951.7,0
+		S3014,1937.8,2475.9,2475.9z"/>
+	<polygon class="st1" points="1161.5,1693.1 955.7,1693.1 1163.6,734.8 2285.2,734.8 2000.2,1107.8 1523.2,1107.8 1474.4,1334.1 
+		1827.3,1334.1 936.1,2499.2 	"/>
+</g>
+</svg>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adding the bridge information for the Flashstake token. The Flashstake token deployed on Optimism was performed using the L2StandardTokenFactory contract.

Deployment details: https://optimistic.etherscan.io/tx/0xb4682fed21ac89736d8f1b4b47bd0e4923d04b8d91e6f757477cb93baaa776b5

**Tests**

We have deployed the Optimism token as mentioned above. There were two test transactions made to ensure funds were bridged successfully. Details: https://optimistic.etherscan.io/token/0x86bea60374f220de9769b2fef2db725bc1cdd335

**Additional context**

N/A

**Metadata**

N/A
