### PR TITLE
Add data for LQTY

### DIFF
--- a/LQTY/data.json
+++ b/LQTY/data.json
@@ -1,0 +1,15 @@
+{
+  "name": "Liquity",
+  "symbol": "LQTY",
+  "decimals": 18,
+  "description": "Interesting free borrowing of LUSD on Ethereum, secured against ETH collateral by immutable code.",
+  "website": "https://www.liquity.org/",
+  "twitter": "@LiquityProtocol",
+  "tokens": {
+    "ethereum": {
+      "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D"
+    },
+    "arbitrum": {
+      "address": "0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449"
+  }
+}


### PR DESCRIPTION
Adds LQTY to the token list. Currently, this doesn't include the address of LQTY on Optimism mainnet because the token is not deployed there yet. LQTY is live only on mainnet and Arbitrum so far.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
