### PR TITLE
FE-1380: validate all standard l2 tokens using StandardL2TokenCreated event

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -1,6 +1,8 @@
 import { ethers } from 'ethers'
 
-export const NETWORK_DATA = {
+import { Network } from './types'
+
+export const NETWORK_DATA: { [network: string]: Network } = {
   ethereum: {
     id: 1,
     name: 'Mainnet',
@@ -41,7 +43,6 @@ export const NETWORK_DATA = {
       84531
     ),
     layer: 2,
-    pair: 'goerli',
     bridge: '0x4200000000000000000000000000000000000010',
   },
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { providers } from 'ethers'
+
 export interface Token {
   address: string
   overrides?: {
@@ -29,4 +31,12 @@ export interface TokenData {
 export interface ValidationResult {
   type: 'error' | 'warning'
   message: string
+}
+
+export interface Network {
+  id: number
+  name: string
+  provider: providers.BaseProvider
+  layer: number
+  bridge: string
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -86,10 +86,11 @@ export const validate = async (
     for (const [chain, token] of Object.entries(data.tokens)) {
       // Validate any standard tokens
       if (folder !== 'ETH' && data.nonstandard !== true) {
+        const networkData = NETWORK_DATA[chain]
         const contract = new ethers.Contract(
           token.address,
           TOKEN_ABI,
-          NETWORK_DATA[chain].provider
+          networkData.provider
         )
 
         // Check that the token exists on this chain
@@ -181,11 +182,11 @@ export const validate = async (
           }
         }
 
-        if (chain.startsWith('optimism')) {
+        if (networkData.layer === 2) {
           const factory = new ethers.Contract(
             '0x4200000000000000000000000000000000000012',
             FACTORY_ABI,
-            NETWORK_DATA[chain].provider
+            networkData.provider
           )
 
           const events = await factory.queryFilter(


### PR DESCRIPTION
Fixes #[FE-1380](https://linear.app/optimism/issue/FE-1380/validate-base-goerli-using-standard-l2-factory)