### PR TITLE
Add nobridge to frxETH

### DIFF
--- a/data/frxETH/data.json
+++ b/data/frxETH/data.json
@@ -4,6 +4,7 @@
     "decimals": 18,
     "website": "https://frax.finance/",
     "twitter": "@fraxfinance",
+    "nobridge": true,
     "tokens": {
         "ethereum": {
             "address": "0x5e8422345238f34275888049021821e8e08caa1f"


### PR DESCRIPTION
No l2Bridge method is defined.

https://community.optimism.io/docs/developers/bridge/standard-bridge/#depositing-erc20s
