### PR TITLE
FE-1365: Fix generate workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -17,7 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT }}
           fetch-depth: 0
 
       - name: Use Node.js 16.x

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/tokenlist",
   "description": "[Optimism] token list",
-  "version": "6.3.16",
+  "version": "6.3.15",
   "main": "index.js",
   "homepage": "https://github.com/ethereum-optimism/tokenlist#readme",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/tokenlist",
   "description": "[Optimism] token list",
-  "version": "6.3.15",
+  "version": "6.3.16",
   "main": "index.js",
   "homepage": "https://github.com/ethereum-optimism/tokenlist#readme",
   "license": "MIT",


### PR DESCRIPTION
To get this working, I changed the checkout step to not use the PAT token. The action now defaults to using the GITHUB_TOKEN token. Here is a [link](https://github.com/ethereum-optimism/ethereum-optimism.github.io/actions/runs/4633522133) to a successful run of the job after making this change.