### PR TITLE
FE-1425: Add opTokenId field to tokenlist

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -48,6 +48,7 @@ export const generate = (datadir: string) => {
             opListId: defaultTokenDataFolders.has(folder.toUpperCase())
               ? 'default'
               : 'extended',
+            opTokenId: folder,
           },
         }
         if (data.nobridge) {

--- a/tests/__snapshots__/generate.test.ts.snap
+++ b/tests/__snapshots__/generate.test.ts.snap
@@ -17,6 +17,7 @@ Object {
       "decimals": 18,
       "extensions": Object {
         "opListId": "default",
+        "opTokenId": "ETH",
         "optimismBridgeAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
       },
       "logoURI": "https://ethereum-optimism.github.io/data/ETH/logo.svg",
@@ -29,6 +30,7 @@ Object {
       "decimals": 18,
       "extensions": Object {
         "opListId": "default",
+        "opTokenId": "ETH",
         "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
       },
       "logoURI": "https://ethereum-optimism.github.io/data/ETH/logo.svg",
@@ -41,6 +43,7 @@ Object {
       "decimals": 18,
       "extensions": Object {
         "opListId": "extended",
+        "opTokenId": "OP",
       },
       "logoURI": "https://ethereum-optimism.github.io/data/OP/logo.png",
       "name": "Optimism",


### PR DESCRIPTION
This is a unique, required field that will be utilized by the Optimism Bridge UI in order to join tokens across chains.