### PR TITLE
Remove nobridge from COLLAb

### DIFF
--- a/data/COLLAB/data.json
+++ b/data/COLLAB/data.json
@@ -5,7 +5,7 @@
   "website": "https://collab.land",
   "description": "Communities with Skin in the Game",
   "twitter": "@Collab_Land_",
-  "nobridge": true,
+  "nobridge": false,
   "tokens": {
     "ethereum": {
       "address": "0x8B21e9b7dAF2c4325bf3D18c1BeB79A347fE902A"


### PR DESCRIPTION
Collab token was updated to include l2bridge method. Removing no bridge flag
