### PR TITLE
FE-1512: Add baseBridgeAddress extension for specifying base specific bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,50 @@ If you require overrides for specific tokens, you can include the `overrides` fi
 }
 ```
 
+##### Bridge overrides
+To override an L1 bridge address, specify the L2 chain it bridges to along with the address of the L1 bridge. For an L2 bridge address override, just specify the address of the L2 bridge.
+
+Here is an example:
+
+```
+{
+  "name": "Synthetix",
+  "symbol": "SNX",
+  "decimals": 18,
+  "tokens": {
+    "ethereum": {
+      "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+      "overrides": {
+        "bridge": {
+          "optimism": "0x39Ea01a0298C315d149a490E34B59Dbf2EC7e48F"
+        }
+      }
+    },
+    "optimism": {
+      "address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+      "overrides": {
+        "bridge": "0x136b1EC699c62b0606854056f02dC7Bb80482d63"
+      }
+    },
+    "goerli": {
+      "address": "0x51f44ca59b867E005e48FA573Cb8df83FC7f7597",
+      "overrides": {
+        "bridge": {
+          "optimism-goerli": "0x1427Bc44755d9Aa317535B1feE38922760Aa4e65"
+        }
+      }
+    },
+    "optimism-goerli": {
+      "address": "0x2E5ED97596a8368EB9E44B1f3F25B2E813845303",
+      "overrides": {
+        "bridge": "0xD2b3F0Ea40dB68088415412b0043F37B3088836D"
+      }
+    }
+  }
+}
+```
+
+
 ### Create a pull request
 
 Open a [pull request](https://github.com/ethereum-optimism/ethereum-optimism.github.io/pulls) with the changes that you've made. Please only add one token per pull request to simplify the review process. This means two new files inside of one new folder. If you want to add multiple tokens, please open different PRs for each token.

--- a/data/BitBTC/data.json
+++ b/data/BitBTC/data.json
@@ -6,7 +6,9 @@
     "ethereum": {
       "address": "0x3C513dB8Bdc3806e4489d62C3d549A5Aaf6A4e97",
       "overrides": {
-        "bridge": "0xaBA2c5F108F7E820C049D5Af70B16ac266c8f128"
+        "bridge": {
+          "optimism": "0xaBA2c5F108F7E820C049D5Af70B16ac266c8f128"
+        }
       }
     },
     "optimism": {

--- a/data/DAI/data.json
+++ b/data/DAI/data.json
@@ -6,7 +6,9 @@
     "ethereum": {
       "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
       "overrides": {
-        "bridge": "0x10E6593CDda8c58a1d0f14C5164B376352a55f2F"
+        "bridge": {
+          "optimism": "0x10E6593CDda8c58a1d0f14C5164B376352a55f2F"
+        }
       }
     },
     "optimism": {
@@ -18,7 +20,9 @@
     "goerli": {
       "address": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
       "overrides": {
-        "bridge": "0x05a388Db09C2D44ec0b00Ee188cD42365c42Df23"
+        "bridge": {
+          "optimism-goerli":  "0x05a388Db09C2D44ec0b00Ee188cD42365c42Df23"
+        }
       }
     },
     "optimism-goerli": {

--- a/data/ECO/data.json
+++ b/data/ECO/data.json
@@ -10,7 +10,9 @@
         "goerli": {
             "address": "0x3E87d4d9E69163E7590f9b39a70853cf25e5ABE3",
             "overrides": {
-                "bridge": "0x7a01E277B8fDb8CDB2A2258508514716359f44A0"
+                "bridge": {
+                    "optimism-goerli": "0x7a01E277B8fDb8CDB2A2258508514716359f44A0"
+                }
             }
         },
         "optimism-goerli": {

--- a/data/SNX/data.json
+++ b/data/SNX/data.json
@@ -6,7 +6,9 @@
     "ethereum": {
       "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
       "overrides": {
-        "bridge": "0x39Ea01a0298C315d149a490E34B59Dbf2EC7e48F"
+        "bridge": {
+          "optimism": "0x39Ea01a0298C315d149a490E34B59Dbf2EC7e48F"
+        }
       }
     },
     "optimism": {
@@ -18,7 +20,9 @@
     "goerli": {
       "address": "0x51f44ca59b867E005e48FA573Cb8df83FC7f7597",
       "overrides": {
-        "bridge": "0x1427Bc44755d9Aa317535B1feE38922760Aa4e65"
+        "bridge": {
+          "optimism-goerli": "0x1427Bc44755d9Aa317535B1feE38922760Aa4e65"
+        }
       }
     },
     "optimism-goerli": {

--- a/data/USX/data.json
+++ b/data/USX/data.json
@@ -6,7 +6,9 @@
     "ethereum": {
       "address": "0x0a5e677a6a24b2f1a2bf4f3bffc443231d2fdec8",
       "overrides": {
-        "bridge": "0xC5b1EC605738eF73a4EFc562274c1c0b6609cF59"
+        "bridge": {
+          "optimism": "0xC5b1EC605738eF73a4EFc562274c1c0b6609cF59"
+        }
       }
     },
     "optimism": {

--- a/data/sUSD/data.json
+++ b/data/sUSD/data.json
@@ -6,7 +6,9 @@
     "ethereum": {
       "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
       "overrides": {
-        "bridge": "0x39Ea01a0298C315d149a490E34B59Dbf2EC7e48F"
+        "bridge": {
+          "optimism": "0x39Ea01a0298C315d149a490E34B59Dbf2EC7e48F"
+        }
       }
     },
     "optimism": {
@@ -18,7 +20,9 @@
     "goerli": {
       "address": "0xB1f664162c0269A469a699709D37cc5739379dD1",
       "overrides": {
-        "bridge": "0x1427Bc44755d9Aa317535B1feE38922760Aa4e65"
+        "bridge": {
+          "optimism-goerli": "0x1427Bc44755d9Aa317535B1feE38922760Aa4e65"
+        }
       }
     },
     "optimism-goerli": {

--- a/data/wstETH/data.json
+++ b/data/wstETH/data.json
@@ -6,7 +6,9 @@
     "ethereum": {
       "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
       "overrides": {
-        "bridge": "0x76943C0D61395d8F2edF9060e1533529cAe05dE6"
+        "bridge": {
+          "optimism": "0x76943C0D61395d8F2edF9060e1533529cAe05dE6"
+        }
       }
     },
     "optimism": {

--- a/optimism.tokenlist.json
+++ b/optimism.tokenlist.json
@@ -6,7 +6,7 @@
     "layer2",
     "infrastructure"
   ],
-  "timestamp": "2023-06-05T17:09:08.884Z",
+  "timestamp": "2023-06-08T23:03:41.694Z",
   "tokens": [
     {
       "chainId": 1,
@@ -208,7 +208,7 @@
       "decimals": 8,
       "logoURI": "https://ethereum-optimism.github.io/data/APT/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x636Af16bf2f682dD3109e60102b8E1A089FedAa8",
+        "baseBridgeAddress": "0xfa6d8ee5be770f84fc001d098c4bd604fe01284a",
         "opListId": "extended",
         "opTokenId": "APT"
       }
@@ -221,7 +221,7 @@
       "decimals": 8,
       "logoURI": "https://ethereum-optimism.github.io/data/APT/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "extended",
         "opTokenId": "APT"
       }
@@ -441,6 +441,7 @@
       "logoURI": "https://ethereum-optimism.github.io/data/cbETH/logo.svg",
       "extensions": {
         "optimismBridgeAddress": "0x636Af16bf2f682dD3109e60102b8E1A089FedAa8",
+        "baseBridgeAddress": "0xfa6d8ee5be770f84fc001d098c4bd604fe01284a",
         "opListId": "default",
         "opTokenId": "cbETH"
       }
@@ -466,7 +467,7 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/cbETH/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "default",
         "opTokenId": "cbETH"
       }
@@ -531,7 +532,6 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/COMP/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
         "opListId": "extended",
         "opTokenId": "COMP"
       }
@@ -545,6 +545,7 @@
       "logoURI": "https://ethereum-optimism.github.io/data/COMP/logo.svg",
       "extensions": {
         "optimismBridgeAddress": "0x636Af16bf2f682dD3109e60102b8E1A089FedAa8",
+        "baseBridgeAddress": "0xfa6d8ee5be770f84fc001d098c4bd604fe01284a",
         "opListId": "extended",
         "opTokenId": "COMP"
       }
@@ -570,7 +571,7 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/COMP/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "extended",
         "opTokenId": "COMP"
       }
@@ -1497,7 +1498,6 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/JRT/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
         "opListId": "extended",
         "opTokenId": "JRT"
       }
@@ -2484,7 +2484,6 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/RSR/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
         "opListId": "extended",
         "opTokenId": "RSR"
       }
@@ -2497,7 +2496,7 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/RSR/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x636Af16bf2f682dD3109e60102b8E1A089FedAa8",
+        "baseBridgeAddress": "0xfa6d8ee5be770f84fc001d098c4bd604fe01284a",
         "opListId": "extended",
         "opTokenId": "RSR"
       }
@@ -2510,7 +2509,7 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/RSR/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "extended",
         "opTokenId": "RSR"
       }
@@ -2689,7 +2688,7 @@
       "decimals": 9,
       "logoURI": "https://ethereum-optimism.github.io/data/SOL/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x636Af16bf2f682dD3109e60102b8E1A089FedAa8",
+        "baseBridgeAddress": "0xfa6d8ee5be770f84fc001d098c4bd604fe01284a",
         "opListId": "extended",
         "opTokenId": "SOL"
       }
@@ -2702,7 +2701,7 @@
       "decimals": 9,
       "logoURI": "https://ethereum-optimism.github.io/data/SOL/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "extended",
         "opTokenId": "SOL"
       }
@@ -3693,7 +3692,7 @@
     }
   ],
   "version": {
-    "major": 7,
+    "major": 8,
     "minor": 3,
     "patch": 62
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/tokenlist",
   "description": "[Optimism] token list",
-  "version": "7.3.62",
+  "version": "8.3.62",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 
-import { Chain, Network } from './types'
+import { Chain, L1Chain, L2Chain, Network } from './types'
 
 export const NETWORK_DATA: Record<Chain, Network> = {
   ethereum: {
@@ -8,7 +8,6 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     name: 'Mainnet',
     provider: new ethers.providers.InfuraProvider('homestead'),
     layer: 1,
-    bridge: '0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1',
   },
   optimism: {
     id: 10,
@@ -17,14 +16,12 @@ export const NETWORK_DATA: Record<Chain, Network> = {
       'https://mainnet.optimism.io'
     ),
     layer: 2,
-    bridge: '0x4200000000000000000000000000000000000010',
   },
   goerli: {
     id: 5,
     name: 'Goerli',
     provider: new ethers.providers.InfuraProvider('goerli'),
     layer: 1,
-    bridge: '0x636Af16bf2f682dD3109e60102b8E1A089FedAa8',
   },
   'optimism-goerli': {
     id: 420,
@@ -33,7 +30,6 @@ export const NETWORK_DATA: Record<Chain, Network> = {
       'https://goerli.optimism.io'
     ),
     layer: 2,
-    bridge: '0x4200000000000000000000000000000000000010',
   },
   'base-goerli': {
     id: 84531,
@@ -43,12 +39,57 @@ export const NETWORK_DATA: Record<Chain, Network> = {
       84531
     ),
     layer: 2,
-    bridge: '0x4200000000000000000000000000000000000010',
   },
 }
 
-export const L2_TO_L1_PAIR: Partial<Record<Chain, Chain>> = {
+interface L2BridgeInformation {
+  l2StandardBridgeAddress: string
+}
+
+interface L1BridgeInformation {
+  l2Chain: L2Chain
+  l1StandardBridgeAddress: string
+}
+
+export const L2_STANDARD_BRIDGE_INFORMATION: Record<
+  L2Chain,
+  L2BridgeInformation
+> = {
+  optimism: {
+    l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
+  },
+  'optimism-goerli': {
+    l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
+  },
+  'base-goerli': {
+    l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
+  },
+}
+
+export const L2_TO_L1_PAIR: Partial<Record<L2Chain, L1Chain>> = {
   optimism: 'ethereum',
   'optimism-goerli': 'goerli',
   'base-goerli': 'goerli',
+}
+
+export const L1_STANDARD_BRIDGE_INFORMATION: Record<
+  L1Chain,
+  L1BridgeInformation[]
+> = {
+  ethereum: [
+    {
+      l2Chain: 'optimism',
+      l1StandardBridgeAddress: '0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1',
+    },
+  ],
+  goerli: [
+    {
+      l2Chain: 'optimism-goerli',
+      l1StandardBridgeAddress: '0x636Af16bf2f682dD3109e60102b8E1A089FedAa8',
+    },
+    {
+      l2Chain: 'base-goerli',
+      l1StandardBridgeAddress: '0xfa6d8ee5be770f84fc001d098c4bd604fe01284a',
+    },
+  ],
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,10 @@ import { providers } from 'ethers'
 export interface Token {
   address: string
   overrides?: {
-    bridge?: string
+    // This is set to a string for l2 tokens and a map for
+    // l1 tokens in order to map from l1 to the appropriate
+    // l2 bridge.
+    bridge?: string | Partial<Record<L2Chain, string>>
     name?: string
     symbol?: string
     decimals?: number
@@ -22,6 +25,17 @@ export type Chain =
   | 'goerli'
   | 'optimism-goerli'
   | 'base-goerli'
+
+const l2Chains = ['optimism', 'optimism-goerli', 'base-goerli'] as const
+export type L2Chain = typeof l2Chains[number]
+
+export const isL2Chain = (chain: string): chain is L2Chain => {
+  return l2Chains.includes(chain as L2Chain)
+}
+
+export const isL1Chain = (chain: string): chain is L1Chain => !isL2Chain(chain)
+
+export type L1Chain = 'ethereum' | 'goerli'
 
 export interface TokenData {
   nonstandard?: boolean
@@ -50,5 +64,4 @@ export interface Network {
   name: string
   provider: providers.BaseProvider
   layer: number
-  bridge: string
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -14,9 +14,19 @@ import { getContractInterface } from '@eth-optimism/contracts'
 
 import { generate } from './generate'
 import { TOKEN_DATA_SCHEMA } from './schemas'
-import { L2_TO_L1_PAIR, NETWORK_DATA } from './chains'
+import {
+  L2_STANDARD_BRIDGE_INFORMATION,
+  L2_TO_L1_PAIR,
+  NETWORK_DATA,
+} from './chains'
 import { TOKEN_ABI } from './abi'
-import { Chain, ExpectedMismatches, TokenData, ValidationResult } from './types'
+import {
+  Chain,
+  ExpectedMismatches,
+  L2Chain,
+  TokenData,
+  ValidationResult,
+} from './types'
 
 /**
  * Validates a token list data folder.
@@ -224,7 +234,10 @@ export const validate = async (
                 // Trigger review if the bridge for the token is not set
                 // to the standard bridge address.
                 if (
-                  l2Bridge?.toUpperCase() !== networkData.bridge.toUpperCase()
+                  l2Bridge?.toUpperCase() !==
+                  L2_STANDARD_BRIDGE_INFORMATION[
+                    chain as L2Chain
+                  ].l2StandardBridgeAddress.toUpperCase()
                 ) {
                   results.push({
                     type: 'error',

--- a/tests/__snapshots__/generate.test.ts.snap
+++ b/tests/__snapshots__/generate.test.ts.snap
@@ -51,7 +51,7 @@ Object {
     },
   ],
   "version": Object {
-    "major": 7,
+    "major": 8,
     "minor": 3,
     "patch": Any<Number>,
   },


### PR DESCRIPTION
This will unblock people from adding base tokens to the tokenlist and will not be a breaking change to any consumers that are currently using the `optimismBridgeAddress` extension for optimism assets.

This has potential to be a breaking change for consumers that are using this token to bridge base assets. If using this for base assets, the `baseBridgeAddress` extension should be used instead of the `optimismBridgeAddress` for tokens that are being bridged on base.

Long term, we should specify bridges by creating a mapping from chain id to bridge address.