### PR TITLE
remove base-goerli config from RSR

### DIFF
--- a/data/RSR/data.json
+++ b/data/RSR/data.json
@@ -14,12 +14,6 @@
       "overrides": {
         "name": "Goerli Reserve RSR"
       }
-    },
-    "base-goerli": {
-      "address": "0xc8058960a9d7E7d81143BDBA38d19e6824165932",
-      "overrides": {
-        "name": "Base Goerli Reserve RSR"
-      }
     }
   }
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Revert the base-goerli section from RSR config 