### PR TITLE
use OptimismBot token to create label

### DIFF
--- a/.github/workflows/label-base-token.yml
+++ b/.github/workflows/label-base-token.yml
@@ -37,5 +37,5 @@ jobs:
         if: steps.check.outputs.add_label == 'true'
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github_token: ${{secrets.PAT}}
           labels: 'base-goerli'


### PR DESCRIPTION
Uses OptimismBot token to create PR label, since it requires enhanced permissions compared to other actions.