### PR TITLE
github/workflows/stale: s/7/30/

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          stale-issue-message: 'This issue has been automatically marked as stale and will be closed in 7 days if no updates'
-          stale-pr-message: 'This pr has been automatically marked as stale and will be closed in 7 days if no updates'
+          stale-issue-message: 'This issue has been automatically marked as stale and will be closed in 30 days if no updates'
+          stale-pr-message: 'This pr has been automatically marked as stale and will be closed in 30 days if no updates'
           close-issue-message: 'This issue was closed as stale.  Please reopen if this is a mistake'
           close-pr-message: 'This PR was closed as stale.  Please reopen if this is a mistake'
-          days-before-issue-stale: 7
-          days-before-pr-stale: 7
-          days-before-issue-close: 7
-          days-before-pr-close: 7
+          days-before-issue-stale: 30
+          days-before-pr-stale: 30
+          days-before-issue-close: 30
+          days-before-pr-close: 30


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

This PR resolves #402, which would ensure contributors don't have to return regularly to keep their discussion alive under the current 7 day threshold (Examples: #385, #402) or reopen/resubmit PRs that get closed because they haven't been reviewed or responded to yet (Examples: #406, #405, #404).

If welcome, no problem to change the threshold to something else, please let me know if so! 👍 This PR changes the threshold from 7d to 30d.

**Tests**

N/A

**Additional context**

N/A