### PR TITLE
remove SOL/APT base-goerli token listings

### DIFF
--- a/data/APT/data.json
+++ b/data/APT/data.json
@@ -5,6 +5,7 @@
   "description": "APT from Aptos, bridged by Wormhole.",
   "website": "https://wormhole.com",
   "twitter": "@wormholecrypto",
+  "nobridge": true,
   "tokens": {
     "ethereum": {
       "address": "0x8CDf7AF57E4c8B930e1B23c477c22f076530585e"

--- a/data/APT/data.json
+++ b/data/APT/data.json
@@ -14,9 +14,6 @@
     },
     "goerli": {
       "address": "0xd7A89a8DD20Cb4F252c7FB96B6421b37d82cE506"
-    },
-    "base-goerli": {
-      "address": "0xd934A15FfA3945DD0Ba2cb7b4174024261A14874"
     }
   }
 }

--- a/data/SOL/data.json
+++ b/data/SOL/data.json
@@ -5,6 +5,7 @@
   "description": "SOL from Solana, bridged by Wormhole.",
   "website": "https://wormhole.com",
   "twitter": "@wormholecrypto",
+  "nobridge": true,
   "tokens": {
     "ethereum": {
       "address": "0xD31a59c85aE9D8edEFeC411D448f90841571b89c"

--- a/data/SOL/data.json
+++ b/data/SOL/data.json
@@ -14,9 +14,6 @@
     },
     "goerli": {
       "address": "0x494701CE895389d917a938f0ea202D4eB9684Eab"
-    },
-    "base-goerli": {
-      "address": "0x6Fb1dE2372e48fe66c84cf37cc2fb54EaEe62988"
     }
   }
 }


### PR DESCRIPTION
These base related token listings were not routed through CB for approval and will have to be resubmitted.

cc @aadam-10 & apologies for the confusion
