### PR TITLE
add WETH for ethereum, base-mainnet, and optimism-goerli networks

### DIFF
--- a/data/WETH/data.json
+++ b/data/WETH/data.json
@@ -4,7 +4,16 @@
   "decimals": 18,
   "nobridge": true,
   "tokens": {
+    "ethereum": {
+      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    },    
     "optimism": {
+      "address": "0x4200000000000000000000000000000000000006"
+    },
+    "optimism-goerli": {
+      "address": "0x4200000000000000000000000000000000000006"
+    },
+    "base": {
       "address": "0x4200000000000000000000000000000000000006"
     },
     "base-goerli": {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

For WETH we have optimism and base-goerli but not ethereum, optimism-goerli and (now) base-mainnet. Adding those in for consistency.
