### PR TITLE
tokenlist: Fix Chain ID for Base

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -18,11 +18,10 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     layer: 2,
   },
   base: {
-    id: 8543,
+    id: 8453,
     name: 'Base',
     provider: new ethers.providers.StaticJsonRpcProvider(
-      // Update to 'https://mainnet.base.org' once live
-      'https://developer-access-mainnet.base.org',
+      'https://mainnet.base.org',
     ),
     layer: 2,
   },


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The Chain ID has a typo on some assets and also in `src/chains.ts`; this fixes it to be 8453 instead of 8543. This also updates the mainnet RPC now that it is live.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
