### PR TITLE
Update Base token instructions to use alternate token factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Please note that by adding a token to the list we aren’t making any claims abo
 ### Base tokens
 For right now, `Base` tokens go through a separate review process. So, if you are adding tokens across both `Optimism` and `Base`, please separate this pull request into separate pull requests for each chain, in order to streamline the review process. If you are adding a token to a `Base` chain (e.g. `base` [mainnet] or `base-goerli` [testnet]) please add [@roberto-bayardo](https://github.com/roberto-bayardo) as a reviewer as they are the point of contact for `Base` tokens and must approve all `Base` tokens before they are merged.
 
+Instead of using the predeploy token factory on Base, we recommend you use the token factory at this [alternate address](https://github.cbhq.net/protocols/base-web) for the time being to avoid having a token address that may conflict with a different token on Optimism.
+
 ### Automated checks
 
 Our CI performs a series of automated checks on every PR.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Right now the Base and Optimism token factories generate identical token address sequences leading to address conflicts across the two chains.   This PR adds instructions for anyone adding a Base token to use an alternate factory contract while we sort this out.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
