### PR TITLE
mark frax tokens as nobridge:true

### DIFF
--- a/data/FRAX/data.json
+++ b/data/FRAX/data.json
@@ -5,7 +5,7 @@
     "description": "Frax is a fractional-algorithmic stablecoin protocol. It aims to provide a highly scalable, decentralized, algorithmic money in place of fixed-supply assets like BTC. Additionally, FXS is the value accrual and governance token of the entire Frax ecosystem.",
     "website": "https://app.frax.finance/",
     "twitter": "@fraxfinance",
-    "nobridge": false,
+    "nobridge": true,
     "tokens": {
       "ethereum": {
         "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e"

--- a/data/FXS/data.json
+++ b/data/FXS/data.json
@@ -5,7 +5,7 @@
     "description": "Frax Shares (FXS) is the seigniorage token in the Frax protocol.",
     "website": "https://app.frax.finance/",
     "twitter": "@fraxfinance",
-    "nobridge": false,
+    "nobridge": true,
     "tokens": {
       "ethereum": {
         "address": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0"

--- a/data/frxETH/data.json
+++ b/data/frxETH/data.json
@@ -4,7 +4,7 @@
     "decimals": 18,
     "website": "https://frax.finance/",
     "twitter": "@fraxfinance",
-    "nobridge": false,
+    "nobridge": true,
     "tokens": {
         "ethereum": {
             "address": "0x5e8422345238f34275888049021821e8e08caa1f"


### PR DESCRIPTION
Frax tokens follow a custom bridge implementation. nobridge should be set to true for the following PRs merged in

#472,
#473,
#474