### PR TITLE
chore: Remove automatic updates

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -50,14 +50,6 @@ pull_request_rules:
         message: |
           Merge failed. Please see automated check logs for more details.
 
-  - name: automatic update prs
-    conditions:
-      - -conflict
-      - -draft
-      - label!="do-not-merge"
-      - 'base=master'
-    actions:
-      update:
 
   - name: Say hi to contributors if they are not part of the regularcontributors team
     conditions:


### PR DESCRIPTION
- remove automatic updates as it makes maintence of tokenlist significantly more difficult
- Because tokens are added independently this is unlikely to cause issues of 2 tokens conflicting with each other. It's unlikely someone updates the same token in 2 open prs