### PR TITLE
Add l1 USDC tokens to `BridgedUSDC`

### DIFF
--- a/data/BridgedUSDC/data.json
+++ b/data/BridgedUSDC/data.json
@@ -6,6 +6,12 @@
   "website": "https://www.circle.com/en/usdc",
   "twitter": "@circlepay",
   "tokens": {
+    "ethereum": {
+      "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    },
+    "goerli": {
+      "address": "0x07865c6E87B9F70255377e024ace6630C1Eaa37F"
+    },
     "base": {
       "address": "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
       "overrides": {


### PR DESCRIPTION
PR https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/537/files introduced a new token `BridgedUSDC`, however in order for this token to be bridgeable it needs to contain both l1 and l2 tokens. This PR adds the L1 USDC tokens to `BridgedUSDC`
