### PR TITLE
Remove ecopod from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ethereum-optimism/devxpod @ethereum-optimism/ecopod
+* @ethereum-optimism/devxpod


### PR DESCRIPTION
Removing ecopod from CODEOWNERS as devx team has been DRI for tokenlist PRs.