### PR TITLE
adding mintable base erc20 contract address of ARPA

### DIFF
--- a/data/ARPA/data.json
+++ b/data/ARPA/data.json
@@ -11,6 +11,9 @@
       },
       "optimism": {
         "address": "0x334cc734866E97D8452Ae6261d68Fd9bc9BFa31E"
+      },
+      "base": {
+        "address": "0x1C9Fa01e87487712706Fb469a13bEb234262C867"
       }
     }
   }


### PR DESCRIPTION
Adding BASE mainnet mintable ERC20 contract address of ARPA

BASE:
https://basescan.org/address/0x1c9fa01e87487712706fb469a13beb234262c867

Ethereum:
https://etherscan.io/token/0xBA50933C268F567BDC86E1aC131BE072C6B0b71a