### PR TITLE
Add USDT token address in Mode chain

### DIFF
--- a/data/USDT/data.json
+++ b/data/USDT/data.json
@@ -20,6 +20,9 @@
     },
     "pgn": {
       "address": "0x6535b3db9B908a2bbA29F83c168a0e661C3fAbf7"
+    },
+    "mode": {
+      "address": "0xf0F161fDA2712DB8b566946122a5af183995e2eD"
     }
   }
 }

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -35,6 +35,14 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     ),
     layer: 2,
   },
+  mode: {
+    id: 34443,
+    name: 'Mode',
+    provider: new ethers.providers.StaticJsonRpcProvider(
+      'https://mainnet.mode.network',
+    ),
+    layer: 2,
+  },
   goerli: {
     id: 5,
     name: 'Goerli',
@@ -104,6 +112,9 @@ export const L2_STANDARD_BRIDGE_INFORMATION: Record<
   pgn: {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
+  mode: {
+    l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
+  },
   'optimism-goerli': {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
@@ -122,6 +133,7 @@ export const L2_TO_L1_PAIR: Partial<Record<L2Chain, L1Chain>> = {
   optimism: 'ethereum',
   base: 'ethereum',
   pgn: 'ethereum',
+  mode: 'ethereum',
   'optimism-goerli': 'goerli',
   'optimism-sepolia': 'sepolia',
   'base-goerli': 'goerli',
@@ -144,6 +156,10 @@ export const L1_STANDARD_BRIDGE_INFORMATION: Record<
     {
       l2Chain: 'pgn',
       l1StandardBridgeAddress: '0xD0204B9527C1bA7bD765Fa5CCD9355d38338272b',
+    },
+    {
+      l2Chain: 'mode',
+      l1StandardBridgeAddress: '0x735aDBbE72226BD52e818E7181953f42E3b0FF21',
     },
   ],
   goerli: [


### PR DESCRIPTION
This is the main USDT token on Mode network to be used with the StandardBridge and is paired with the USDT token `0xdac17f958d2ee523a2206206994597c13d831ec7` on Ethereum mainnet.

USDT token address on Mode is `0xf0F161fDA2712DB8b566946122a5af183995e2eD` and is referenced in Mode's main docs https://docs.mode.network/mode-developer-mainnet/mainnet-contract-addresses#token-addresses

This token is deployed using OptimismMintableERC20 directly without using the factory because the factory only supports 18 decimals while USDT requires 6 decimals.