### PR TITLE
Add Sepolia SNT and OP Sepolia SNT

### DIFF
--- a/data/SNT/data.json
+++ b/data/SNT/data.json
@@ -24,6 +24,20 @@
         "name": "Status Test Token",
         "symbol": "STT"
       }
+    },
+    "sepolia": {
+      "address": "0xE452027cdEF746c7Cd3DB31CB700428b16cD8E51",
+      "overrides": {
+        "name": "Status Test Token",
+        "symbol": "STT"
+      }
+    },
+    "sepolia-optimism": {
+      "address": "0x0B5DAd18B8791ddb24252B433ec4f21f9e6e5Ed0",
+      "overrides": {
+        "name": "Status Test Token",
+        "symbol": "STT"
+      }
     }
   }
 }

--- a/data/SNT/data.json
+++ b/data/SNT/data.json
@@ -32,7 +32,7 @@
         "symbol": "STT"
       }
     },
-    "sepolia-optimism": {
+    "optimism-sepolia": {
       "address": "0x0B5DAd18B8791ddb24252B433ec4f21f9e6e5Ed0",
       "overrides": {
         "name": "Status Test Token",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Following https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/559, this adds SNT for Sepolia and OP Sepolia to the token bridge UI.

