### PR TITLE
add ether.fi weETH for Base mainnet

### DIFF
--- a/data/weETH/data.json
+++ b/data/weETH/data.json
@@ -17,6 +17,9 @@
     },
     "optimism-goerli": {
       "address": "0x7e7d4467112689329f7E06571eD0E8CbAd4910eE"
+    },
+    "base": {
+      "address": "0x4c94DE27c94962Dba6Ebb77924Ac54189db75EFA"
     }
   }
 }


### PR DESCRIPTION
This is a resubmit of this pr that accidentally got merged without approval: https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/589

add ether.fi weETH for Base mainnet
mainnet: https://basescan.org/address/0x4c94DE27c94962Dba6Ebb77924Ac54189db75EFA#code
