### PR TITLE
Adding OLAS token to Base

### DIFF
--- a/data/OLAS/data.json
+++ b/data/OLAS/data.json
@@ -14,6 +14,9 @@
     },
     "goerli": {
       "address": "0xEdfc28215B1Eb6eb0be426f1f529cf691A5C2400"
+    },
+    "base": {
+      "address": "0x54330d28ca3357F294334BDC454a032e7f353416"
     }
   }
 }

--- a/data/OLAS/data.json
+++ b/data/OLAS/data.json
@@ -1,0 +1,19 @@
+{
+  "name": "Autonolas",
+  "symbol": "OLAS",
+  "decimals": 18,
+  "description": "Crypto's Ocean of Services: The unified network for off-chain services, e.g. automation, relayers and co-owned AI. Coordinated by OLAS, powered by autonomous agents.",
+  "website": "https://olas.network",
+  "twitter": "@autonolas",
+  "tokens": {
+    "ethereum": {
+      "address": "0x0001A500A6B18995B03f44bb040A5fFc28E45CB0"
+    },
+    "optimism": {
+      "address": "0xFC2E6e6BCbd49ccf3A5f029c79984372DcBFE527"
+    },
+    "goerli": {
+      "address": "0xEdfc28215B1Eb6eb0be426f1f529cf691A5C2400"
+    }
+  }
+}

--- a/data/OLAS/logo.svg
+++ b/data/OLAS/logo.svg
@@ -1,0 +1,7 @@
+<svg width="161" height="181" viewBox="0 0 161 181" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M80.8523 181L0.704624 135.936L0.704632 45.8094L80.8523 0.745873L161 45.8094L161 135.936L80.8523 181Z" fill="black"/>
+<path d="M41 60H121V77.4757H41V60Z" fill="white"/>
+<path d="M41 82.5243H121V100H41V82.5243Z" fill="white"/>
+<path d="M41 105.049H76.7282V122.524H41V105.049Z" fill="white"/>
+<path d="M85.2718 105.049H121V122.524H85.2718V105.049Z" fill="white"/>
+</svg>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add OLAS token to the Base network.
Token Ethereum mainnet address: https://etherscan.io/address/0x0001A500A6B18995B03f44bb040A5fFc28E45CB0
Token Base mainnet address: https://basescan.org/address/0x54330d28ca3357F294334BDC454a032e7f353416

@roberto-bayardo 

**Tests**

Tests are not provided as the contract has been deployed by the [OptimismMintableERC20Factory](https://basescan.org/address/0xf23d369d7471bd9f6487e198723eea023389f1d4).

**Additional context**

No additional context.

**Metadata**

N/A
