### PR TITLE
add FOAM to Base

### DIFF
--- a/data/FOAM/data.json
+++ b/data/FOAM/data.json
@@ -11,6 +11,9 @@
       },
       "optimism": {
         "address": "0x79E6c6b6aABA4432FAbacB30cC0C879D8f3E598e"
+      },
+      "base": {
+        "address": "0x6059d0ed9368c36941514d2864fD114a84853d5a"
       }
     }
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds the [FOAM token](https://www.coingecko.com/en/coins/foam) to the Superchain list with Mainnet and Base addresses

ETH Mainnet address: https://etherscan.io/address/0x4946fcea7c692606e8908002e55a582af44ac121
Base address: https://basescan.org/address/0x6059d0ed9368c36941514d2864fD114a84853d5a

**Tests**
N/A, deployed to Base using the Base OptimismMintableERC20Factory at `0xf23d369d7471bd9f6487e198723eea023389f1d4`


**Additional context**

Factory transaction: https://basescan.org/tx/0x14121db9ec5d3ff1327e0367f4352e66d45fb74ac4a4cecf418b670a8b0d359e
