### PR TITLE
Update data.json for USDC sepolia

### DIFF
--- a/data/USDC/data.json
+++ b/data/USDC/data.json
@@ -10,20 +10,20 @@
     "ethereum": {
       "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
     },
-    "goerli": {
-      "address": "0x07865c6E87B9F70255377e024ace6630C1Eaa37F"
+    "sepolia": {
+      "address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
     },
     "base": {
       "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     },
-    "base-goerli": {
-      "address": "0xf175520c52418dfe19c8098071a252da48cd1c19"
+    "base-sepolia": {
+      "address": "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
     },
     "optimism": {
       "address": "0x0b2c639c533813f4aa9d7837caf62653d097ff85"
     },
-    "optimism-goerli": {
-      "address": "0xe05606174bac4A6364B31bd0eCA4bf4dD368f8C6"
+    "optimism-sepolia": {
+      "address": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7"
     }
   }
 }


### PR DESCRIPTION
USDC on EVM testnet has been migrated from goerli towards sepolia in Jan 2024. This is to update the data.json to reflect that.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

USDC on EVM testnet has been migrated from goerli towards sepolia in Jan 2024. This is to update the data.json to reflect that.

**Tests**

Verified them through both internal verification and external etherscan verification. Links are here:
1. Eth sepolia: https://sepolia.etherscan.io/address/0x1c7d4b196cb0c7b01d743fbc6116a902379c7238
2. Base sepolia: https://sepolia.basescan.org/address/0x036cbd53842c5426634e7929541ec2318f3dcf7e
3. OP sepolia: https://sepolia-optimism.etherscan.io/address/0x5fd84259d66cd46123540766be93dfe6d43130d7

**Additional context**

N/A

**Metadata**
