### PR TITLE
Add mode to l2Chains array

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,8 +31,9 @@ export type Chain =
   | 'pgn'
   | 'pgn-sepolia'
   | 'sepolia'
+  | 'mode'
 
-const l2Chains = ['optimism', 'optimism-goerli', 'optimism-sepolia', 'base', 'base-goerli', 'base-sepolia', 'pgn-sepolia', 'pgn'] as const
+const l2Chains = ['optimism', 'optimism-goerli', 'optimism-sepolia', 'base', 'base-goerli', 'base-sepolia', 'pgn-sepolia', 'pgn', 'mode'] as const
 export type L2Chain = typeof l2Chains[number]
 
 export const isL2Chain = (chain: string): chain is L2Chain => {


### PR DESCRIPTION
It looks like this [PR](https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/579), which added the mode chain, never added mode to the `l2Chains` array which caused many of the CI checks and actions for this repo to break