### PR TITLE
feat: add bridged PEPE on base

### DIFF
--- a/data/PEPE/data.json
+++ b/data/PEPE/data.json
@@ -8,6 +8,9 @@
     },
     "optimism": {
       "address": "0xc1c167cc44f7923cd0062c4370df962f9ddb16f5"
+    },
+    "base": {
+      "address": "0xb4fde59a779991bfb6a52253b51947828b982be3"
     }
   }
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Add Pepe address for Base network.


**Tests**

This is updating a token info json with a new address for base network so test is not added.

**Additional context**

L2 Standard token creation tx:
https://basescan.org/tx/0xb6435cbf60cd4d82303d7774a9b9cea97a8cb543f1052fc4bd72ea08622b4331#eventlog

L1 token address:
0x6982508145454Ce325dDbE47a25d4ec3d2311933