### PR TITLE
chore: update the name of RAZOR token to match contract

### DIFF
--- a/data/RAZOR/data.json
+++ b/data/RAZOR/data.json
@@ -1,5 +1,5 @@
 {
-    "name": "Razor Network",
+    "name": "RAZOR",
     "symbol": "RAZOR",
     "decimals": 18,
     "website": "https://razor.network",


### PR DESCRIPTION
- Linked to an update requested on a previous PR which was merged. But the token still does not reflect on the OP bridge UI. 
- https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/736