### PR TITLE
Hotfix #788 - Generate token list manually

### DIFF
--- a/optimism.tokenlist.json
+++ b/optimism.tokenlist.json
@@ -6,7 +6,7 @@
     "layer2",
     "infrastructure"
   ],
-  "timestamp": "2024-04-02T19:25:45.185Z",
+  "timestamp": "2024-04-18T02:44:25.278Z",
   "tokens": [
     {
       "chainId": 1,
@@ -1332,6 +1332,32 @@
     },
     {
       "chainId": 1,
+      "address": "0x5fab9761d60419c9eeebe3915a8fa1ed7e8d2e1b",
+      "name": "Dimo",
+      "symbol": "DIMO",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/DIMO/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "DIMO"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd7ea8433b434223b3da2931620391df157d1c22d",
+      "name": "Dimo",
+      "symbol": "DIMO",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/DIMO/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "DIMO"
+      }
+    },
+    {
+      "chainId": 1,
       "address": "0xbaac2b4491727d78d2b78815144570b9f2fe8899",
       "name": "The Doge NFT",
       "symbol": "DOG",
@@ -1719,6 +1745,58 @@
       }
     },
     {
+      "chainId": 11155111,
+      "address": "0xbABedB663F3E70E6CEdb26558e8ceFB12d321Caa",
+      "name": "Everyrealm Token",
+      "symbol": "EVERY",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/EVERY/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0xfd0Bf71F60660E2f608ed56e1659C450eB113120",
+        "opListId": "extended",
+        "opTokenId": "EVERY"
+      }
+    },
+    {
+      "chainId": 84532,
+      "address": "0xb01701025c3b12e0b5022d8a98f15f8ad3602a7b",
+      "name": "Everyrealm Token",
+      "symbol": "EVERY",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/EVERY/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "EVERY"
+      }
+    },
+    {
+      "chainId": 1,
+      "address": "0x9aFa9999e45484Adf5d8EED8D9Dfe0693BACd838",
+      "name": "Everyworld",
+      "symbol": "EVERY",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/EVERY/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "EVERY"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0x717d31a60a9e811469673429c9f8ea24358990f1",
+      "name": "Everyworld",
+      "symbol": "EVERY",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/EVERY/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "EVERY"
+      }
+    },
+    {
       "chainId": 1,
       "address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
       "name": "FARM Reward Token",
@@ -2070,6 +2148,32 @@
       "extensions": {
         "opListId": "extended",
         "opTokenId": "FXS"
+      }
+    },
+    {
+      "chainId": 1,
+      "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
+      "name": "Aavegotchi GHST Token",
+      "symbol": "GHST",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/GHST/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "GHST"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcd2f22236dd9dfe2356d7c543161d4d260fd9bcb",
+      "name": "Aavegotchi GHST Token",
+      "symbol": "GHST",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/GHST/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "GHST"
       }
     },
     {
@@ -2426,6 +2530,32 @@
     },
     {
       "chainId": 1,
+      "address": "0x9AAb071B4129B083B01cB5A0Cb513Ce7ecA26fa5",
+      "name": "HuntToken",
+      "symbol": "HUNT",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/HUNT/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "HUNT"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0x37f0c2915CeCC7e977183B8543Fc0864d03E064C",
+      "name": "HuntToken",
+      "symbol": "HUNT",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/HUNT/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "HUNT"
+      }
+    },
+    {
+      "chainId": 1,
       "address": "0xF655C8567E0f213e6C634CD2A68d992152161dC6",
       "name": "Impermax",
       "symbol": "IBEX",
@@ -2538,6 +2668,32 @@
         "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "extended",
         "opTokenId": "ISK"
+      }
+    },
+    {
+      "chainId": 1,
+      "address": "0x7cb683151a83c2b10a30cbb003cda9996228a2ba",
+      "name": "IYKYK",
+      "symbol": "IYKYK",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/IYKYK/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "IYKYK"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0xB00d803CB2367a7DA82351DCb9D213230da7B92A",
+      "name": "IYKYK",
+      "symbol": "IYKYK",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/IYKYK/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "IYKYK"
       }
     },
     {
@@ -2837,6 +2993,7 @@
       "logoURI": "https://ethereum-optimism.github.io/data/LRC/logo.png",
       "extensions": {
         "optimismBridgeAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
         "opListId": "extended",
         "opTokenId": "LRC"
       }
@@ -2850,6 +3007,19 @@
       "logoURI": "https://ethereum-optimism.github.io/data/LRC/logo.png",
       "extensions": {
         "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "LRC"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0D760ee479401Bb4C40BDB7604b329FfF411b3f2",
+      "name": "LoopringCoin V2",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/LRC/logo.png",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "extended",
         "opTokenId": "LRC"
       }
@@ -3868,6 +4038,32 @@
     },
     {
       "chainId": 1,
+      "address": "0x8b12bd54ca9b2311960057c8f3c88013e79316e3",
+      "name": "Reach",
+      "symbol": "$Reach",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/REACH/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "REACH"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4379c13143eb91148ff9282cfb2f93536687a45b",
+      "name": "Reach",
+      "symbol": "$Reach",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/REACH/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "REACH"
+      }
+    },
+    {
+      "chainId": 1,
       "address": "0xae78736cd615f374d3085123a210448e74fc6393",
       "name": "Rocket Pool ETH",
       "symbol": "rETH",
@@ -4026,6 +4222,32 @@
     },
     {
       "chainId": 1,
+      "address": "0xd101dcc414f310268c37eeb4cd376ccfa507f571",
+      "name": "ResearchCoin",
+      "symbol": "RSC",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/RSC/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "RSC"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0xFbB75A59193A3525a8825BeBe7D4b56899E2f7e1",
+      "name": "ResearchCoin",
+      "symbol": "RSC",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/RSC/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "RSC"
+      }
+    },
+    {
+      "chainId": 1,
       "address": "0x320623b8e4ff03373931769a31fc52a4e78b5d70",
       "name": "Reserve Rights",
       "symbol": "RSR",
@@ -4074,6 +4296,32 @@
         "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "extended",
         "opTokenId": "SAIL"
+      }
+    },
+    {
+      "chainId": 1,
+      "address": "0x5582a479f0c403e207d2578963ccef5d03ba636f",
+      "name": "Salad",
+      "symbol": "SALD",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/SALD/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "SALD"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2578cdd1603a5a7db9df46998d2e13d0e51db527",
+      "name": "Salad",
+      "symbol": "SALD",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/SALD/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "SALD"
       }
     },
     {
@@ -4464,6 +4712,32 @@
     },
     {
       "chainId": 1,
+      "address": "0xfF836A5821E69066c87E268bC51b849FaB94240C",
+      "name": "Real Smurf Cat",
+      "symbol": "SMURFCAT",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/SMURFCAT/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "SMURFCAT"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2809ee30c77d7887e4f77394a1ac0e49de0e397f",
+      "name": "Real Smurf Cat",
+      "symbol": "SMURFCAT",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/SMURFCAT/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "SMURFCAT"
+      }
+    },
+    {
+      "chainId": 1,
       "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
       "name": "Status Network Token",
       "symbol": "SNT",
@@ -4740,6 +5014,32 @@
         "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "default",
         "opTokenId": "stkLYRA"
+      }
+    },
+    {
+      "chainId": 1,
+      "address": "0x3446dd70b2d52a6bf4a5a192d9b0a161295ab7f9",
+      "name": "SUDO GOVERNANCE TOKEN",
+      "symbol": "SUDO",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/SUDO/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "SUDO"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0x77ba5713f0afcedb4a10fa155b5e95218a7b658e",
+      "name": "SUDO GOVERNANCE TOKEN",
+      "symbol": "SUDO",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/SUDO/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "SUDO"
       }
     },
     {
@@ -6078,6 +6378,32 @@
         "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
         "opListId": "extended",
         "opTokenId": "ZUSD"
+      }
+    },
+    {
+      "chainId": 1,
+      "address": "0x58cB30368ceB2d194740b144EAB4c2da8a917Dcb",
+      "name": "ZynCoin",
+      "symbol": "ZYN",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/ZYN/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        "opListId": "extended",
+        "opTokenId": "ZYN"
+      }
+    },
+    {
+      "chainId": 8453,
+      "address": "0x82c8f48ac694841360de84d649a0d48d239b61f8",
+      "name": "ZynCoin",
+      "symbol": "ZYN",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/ZYN/logo.svg",
+      "extensions": {
+        "baseBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "opListId": "extended",
+        "opTokenId": "ZYN"
       }
     }
   ],


### PR DESCRIPTION
The token list generation continues to fail, preventing updates to the token list file:
https://github.com/ethereum-optimism/ethereum-optimism.github.io/actions/runs/8648354574

Issue reported: https://github.com/ethereum-optimism/ethereum-optimism.github.io/issues/788

The problem might be related to GitHub Actions, since the following command works okay in a local environment:

```sh
pnpm generate --datadir ./data --outfile optimism.tokenlist.json
```

This PR is a manual update for the token list that has been merged on the main branch so far. This could serve as a temporary fix until the issue with GitHub Actions is resolved.