### PR TITLE
Add base l2 token address for UNI

### DIFF
--- a/data/UNI/data.json
+++ b/data/UNI/data.json
@@ -9,6 +9,9 @@
     "optimism": {
       "address": "0x6fd9d7ad17242c41f7131d257212c54a0e816691"
     },
+    "base": {
+      "address": "0xc3De830EA07524a0761646a6a4e4be0e114a3C83"
+    },
     "mode": {
       "address": "0x3e7eF8f50246f725885102E8238CBba33F276747"
     }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adding UNI - Uniswap - token address deployed on Base L2.

**Additional context**

Pinging @cfluke-cb @wbnns per PR instructions. 
