### PR TITLE
Remove noBridge from SNX

### DIFF
--- a/data/SNX/data.json
+++ b/data/SNX/data.json
@@ -2,7 +2,6 @@
   "name": "Synthetix",
   "symbol": "SNX",
   "decimals": 18,
-  "nobridge": true,
   "tokens": {
     "ethereum": {
       "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",


### PR DESCRIPTION
SNX has a canonical implementation on Base and Mode. Per request from Kaleb we are removing the noBridge flag. 

This means users will stay face gas issues when trying to bridge to OPM but the SNX token will show up with the correct syntax going forward. 

See issue 857 in EcoPod repo for more info