### PR TITLE
Revert "Add base L2 token address for MKR"

### DIFF
--- a/data/MKR/data.json
+++ b/data/MKR/data.json
@@ -9,9 +9,6 @@
     },
     "optimism": {
       "address": "0xab7badef82e9fe11f6f33f87bc9bc2aa27f2fcb5"
-    },
-    "base": {
-      "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
     }
   }
 }


### PR DESCRIPTION
Reverts ethereum-optimism/ethereum-optimism.github.io#807 as the provided address is invalid.