### PR TITLE
Update weETH token data

### DIFF
--- a/data/weETH/data.json
+++ b/data/weETH/data.json
@@ -2,6 +2,7 @@
   "name": "Wrapped eETH",
   "symbol": "weETH",
   "decimals": 18,
+  "noBridge": true,
   "description": "Ether.fi Wrapped eETH",
   "website": "https://www.ether.fi/",
   "twitter": "@ether_fi",


### PR DESCRIPTION
Bridges keep on listing the weETH canonical, but we have switched over to an layerzero OFT deployment for all OP stack chains