### PR TITLE
feat-add-mugloo-base-metall2

### DIFF
--- a/data/MUGLOO/data.json
+++ b/data/MUGLOO/data.json
@@ -12,6 +12,12 @@
       },
       "optimism": {
         "address": "0x1164b451624E0D53bD8Be84d3fF7f9591bA8922e"
+      },
+      "base": {
+        "address": "0xE009e453Ac69B0E9602BA091D5331B31B03D3039"
+      },
+      "metall2": {
+        "address": "0xf1F9Ccc7638F124c3d9354Be0edE2ACb5F0A15Bc"
       }
     }
   }

--- a/data/MUGLOO/data.json
+++ b/data/MUGLOO/data.json
@@ -15,9 +15,6 @@
       },
       "base": {
         "address": "0xE009e453Ac69B0E9602BA091D5331B31B03D3039"
-      },
-      "metall2": {
-        "address": "0xf1F9Ccc7638F124c3d9354Be0edE2ACb5F0A15Bc"
       }
     }
   }


### PR DESCRIPTION
**Description**

A cross chain token for my upcoming project for OpStack.
- Already listed for Optimism.

L1 Contract:
Ethereum: [0x8e3c68a9c10d3bf2aaf14f2e569a8223f21bf2b6](https://etherscan.io/address/0x8e3c68a9c10d3bf2aaf14f2e569a8223f21bf2b6)

- L2's 
Base:[0xE009e453Ac69B0E9602BA091D5331B31B03D3039](https://base.blockscout.com/address/0xE009e453Ac69B0E9602BA091D5331B31B03D3039)

Metall2:~[0xf1F9Ccc7638F124c3d9354Be0edE2ACb5F0A15Bc](https://explorer.metall2.com/address/0xf1F9Ccc7638F124c3d9354Be0edE2ACb5F0A15Bc)~

going with Base for now as per below thread, will raise a new one for Metall2