### PR TITLE
Revert "feat-add-mugloo-base-metall2 (#921)"

### DIFF
--- a/data/MUGLOO/data.json
+++ b/data/MUGLOO/data.json
@@ -12,9 +12,6 @@
       },
       "optimism": {
         "address": "0x1164b451624E0D53bD8Be84d3fF7f9591bA8922e"
-      },
-      "base": {
-        "address": "0xE009e453Ac69B0E9602BA091D5331B31B03D3039"
       }
     }
   }


### PR DESCRIPTION
This reverts commit 69b96899b837dfb3ed40a081eca0781af08d432b -- the source code for the deploy smart contract isn't verified; in addition, it's using custom decimals. We should confirm that it's using a contract that bridges won't have issues with, in addition to ensuring the source code is verified.

Contract: https://basescan.org/address/0xE009e453Ac69B0E9602BA091D5331B31B03D3039#code