### PR TITLE
Feat: add USDT token address for Lisk mainnet and testnet

### DIFF
--- a/data/USDT/data.json
+++ b/data/USDT/data.json
@@ -17,6 +17,12 @@
     },
     "mode": {
       "address": "0xf0F161fDA2712DB8b566946122a5af183995e2eD"
+    },
+    "lisk": {
+      "address": "0x05D032ac25d322df992303dCa074EE7392C117b9"
+    },
+    "lisk-sepolia": {
+      "address": "0xd26be7331edd458c7afa6d8b7fcb7a9e1bb68909"
     }
   }
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add USDT contract address for Lisk and Lisk sepolia

**Tests**

We run the tests indicated in the README:

```npx tsx ./bin/cli.ts validate --datadir ./data --tokens USDT```
