### PR TITLE
Adds WBTC on Base

### DIFF
--- a/data/WBTC/data.json
+++ b/data/WBTC/data.json
@@ -14,6 +14,9 @@
     },
     "mode": {
       "address": "0xcDd475325D6F564d27247D1DddBb0DAc6fA0a5CF"
+    },
+    "base": {
+      "address": "0x1a498C0927B1F96e6E5eCDe8071B66774cd411F5"
     }
   }
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds WBTC `Optimism Mintable ERC20With Decimals` contract for Base.

**Additional context**

- `Optimism Mintable ERC20With Decimals` contract was deployed from the Base factory contract in this transaction: https://basescan.org/tx/0xf743f6eae5552a971fb87b0ac6e9fb35e67c9670624d208cb9e365623cbfadf5
- Ethereum mainnet/L1 token matches WBTC token contract located here: https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599
- 8 decimals were specified to match the 8 decimals of the token on Ethereum mainnet/L1
- Token description matches Ethereum mainnet/L1
- Token symbol matches Ethereum mainnet/L1
