### PR TITLE
Add WBTC token to Lisk

### DIFF
--- a/data/WBTC/data.json
+++ b/data/WBTC/data.json
@@ -14,6 +14,9 @@
     },
     "mode": {
       "address": "0xcDd475325D6F564d27247D1DddBb0DAc6fA0a5CF"
+    },
+    "lisk": {
+      "address": "0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3"
     }
   }
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add address for WBTC on Lisk L2.

**Tests**

We ran the WBTC test with:

```npx tsx ./bin/cli.ts validate --datadir ./data --tokens WBTC```