### PR TITLE
Use checksum address for SNT on Ethereum

### DIFF
--- a/data/SNT/data.json
+++ b/data/SNT/data.json
@@ -6,7 +6,7 @@
   "twitter": "@ethstatus",
   "tokens": {
     "ethereum": {
-      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e"
+      "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E"
     },
     "optimism": {
       "address": "0x650AF3C15AF43dcB218406d30784416D64Cfb6B2"


### PR DESCRIPTION
## what

- use checksum address for SNT on Ethereum

## why

- https://eips.ethereum.org/EIPS/eip-55
- when comparing to another token list like https://ipfs.io/ipns/tokens.uniswap.org, SNT on Ethereum would come up as unique but essentially same due to difference in casing
- https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/559

## how (for example)

- https://etherscan.io/address/0x744d70fdbe2ba4cf95131626614a1763df805b9e returns `0x744d70FDBE2Ba4CF95131626614a1763DF805B9E`