### PR TITLE
Add Bridged USDC to Lisk

### DIFF
--- a/data/BridgedUSDC/data.json
+++ b/data/BridgedUSDC/data.json
@@ -7,7 +7,12 @@
   "twitter": "@circlepay",
   "tokens": {
     "ethereum": {
-      "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "overrides": {
+        "bridge": {
+          "lisk": "0xE3622468Ea7dD804702B56ca2a4f88C0936995e6"
+        }
+      }
     },
     "base": {
       "address": "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
@@ -29,6 +34,14 @@
         "name": "Bridged USDC (Lattice)",
         "symbol": "USDC.e",
         "bridge": "0x4200000000000000000000000000000000000010"
+      }
+    },
+    "lisk": {
+      "address": "0xF242275d3a6527d877f2c927a82D9b057609cc71",
+      "overrides": {
+        "name": "Bridged USDC (Lisk)",
+        "symbol": "USDC.e",
+        "bridge": "0x3b1ac69368eb6447F5db2d4E1641380Fa9e40d29"
       }
     }
   }


### PR DESCRIPTION
**Description**

Bridged USDC is deployed on Lisk using [Bridged USDC Standard for the OP Stack](https://github.com/defi-wonderland/opUSDC) which also deploys and uses new L1 and L2 bridges. 

- Added Bridged USDC deployment address, name and synbol on Lisk
- Added L1 bridge address for Lisk on Ethereum 
- Added L2 bridge address on Lisk

**Tests**

Ran validation test indicated in the `README`:

`npx tsx ./bin/cli.ts validate --datadir ./data --tokens USDC`
