### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These issues are marked below as "requires manual review".
 - Description is under 1000 characters (auto-reject)
 - Token `name`, `symbol`, and `decimals` matches on-chain data (auto-reject)
   - If `overrides` are used (requires manual review)
-- L2 token was deployed by the [StandardTokenFactory](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/L2/messaging/L2StandardTokenFactory.sol) or is an [L2StandardERC20](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/standards/L2StandardERC20.sol) token that uses the standard L2 bridge address (`0x4200000000000000000000000000000000000010`) (requires manual review)
+- L2 token was deployed by the [StandardTokenFactory](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/L2/messaging/L2StandardTokenFactory.sol) or is an [L2StandardERC20]() token that uses the standard L2 bridge address (`0x4200000000000000000000000000000000000010`) (requires manual review)
 - Ethereum token listed on the [CoinGecko Token List](https://tokenlists.org/token-list?url=https://tokens.coingecko.com/uniswap/all.json)(requires manual review)
   - *Why CoinGecko? CoinGecko's token list updates every hour which means we get token list updates very quickly. CoinGecko also uses an in-depth [listing criteria](https://www.coingecko.com/en/methodology).*
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These issues are marked below as "requires manual review".
 - Description is under 1000 characters (auto-reject)
 - Token `name`, `symbol`, and `decimals` matches on-chain data (auto-reject)
   - If `overrides` are used (requires manual review)
-- L2 token was deployed by the [StandardTokenFactory](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/L2/messaging/L2StandardTokenFactory.sol) or is an [L2StandardERC20]() token that uses the standard L2 bridge address (`0x4200000000000000000000000000000000000010`) (requires manual review)
+- L2 token was deployed by the [StandardTokenFactory](https://github.com/ethereum-optimism/optimism-legacy/blob/develop/packages/contracts/contracts/L2/messaging/L2StandardTokenFactory.sol) or is an [L2StandardERC20](https://github.com/ethereum-optimism/optimism-legacy/blob/develop/packages/contracts/contracts/standards/L2StandardERC20.sol) token that uses the standard L2 bridge address (`0x4200000000000000000000000000000000000010`) (requires manual review)
 - Ethereum token listed on the [CoinGecko Token List](https://tokenlists.org/token-list?url=https://tokens.coingecko.com/uniswap/all.json)(requires manual review)
   - *Why CoinGecko? CoinGecko's token list updates every hour which means we get token list updates very quickly. CoinGecko also uses an in-depth [listing criteria](https://www.coingecko.com/en/methodology).*
 


### PR DESCRIPTION
Fix: Remove broken L2StandardERC20 link in README.md

I noticed that the link to L2StandardERC20 contract in the README.md is broken:
https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/standards/L2StandardERC20.sol

I've removed this broken link while keeping the reference to L2StandardERC20. 

Please provide an updated link to the current L2StandardERC20 contract implementation so I can update the documentation accordingly.
