### PR TITLE
✨ add AAVE token on base

### DIFF
--- a/data/AAVE/data.json
+++ b/data/AAVE/data.json
@@ -11,6 +11,9 @@
     },
     "mode": {
       "address": "0x7c6b91D9Be155A6Db01f749217d76fF02A7227F2"
+    },
+    "base": {
+      "address": "0x63706e401c06ac8513145b7687A14804d17f814b"
     }
   }
 }


### PR DESCRIPTION
**Description**

Implement the AAVE token on Base.

AAVE token has been deployed on Base on this tx: https://basescan.org/tx/0x1c29e61ba6da00244e6b7f6bb8153b1c8c0de762d562ba65f8369bfb1e9e68b7

- localToken: [0x63706e401c06ac8513145b7687A14804d17f814b](https://basescan.org/address/0x63706e401c06ac8513145b7687A14804d17f814b)  
- remoteToken: [0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9](https://etherscan.io/address/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9)

**Tests**

**Additional context**

**Metadata**