### PR TITLE
add: new SMT addresses for Mode and Lisk networks

### DIFF
--- a/data/SMT/data.json
+++ b/data/SMT/data.json
@@ -14,6 +14,12 @@
     },
     "base": {
       "address": "0x2974dC646e375e83bd1c0342625b49f288987fA4"
+    },
+    "mode" : {
+      "address":"0x06d6a7BDFFAFa3c953d7B9842f7F414a6e0bEb4A"
+    },
+    "lisk": {
+      "address":"0x2fcAb60dc6Ad65be5F2Aae6a1B2E2ecB93017888"
     }
   }
 }


### PR DESCRIPTION
**Description**

Add SMT token support to the Mode and Lisk networks.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

No tests. Used standard token bridge.
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
