### PR TITLE
fix publishing of tokenlist and removing the requirement for not bot push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
     machine:
       image: ubuntu-2204:2024.08.1
     steps:
-      - continue-if-not-bot
       - setup
       - run:
           name: Prepare git
@@ -87,7 +86,13 @@ jobs:
           command: |
             echo "Pushing changes"
             git push "https://x-access-token:${GITHUB_TOKEN_GOVERNANCE}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" $CIRCLE_BRANCH
-
+      - run:
+          name: Configure NPM Token and Registry
+          command: |
+            npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+      - run:
+          name: Verify NPM Token
+          command: npm whoami
       - run:
           name: Publish package
           command: pnpm publish


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request includes updates to the `.circleci/config.yml` file to streamline the CI/CD pipeline by removing an unnecessary step and adding steps to configure and verify the NPM token.

CI/CD pipeline improvements:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L45): Removed the `continue-if-not-bot` step to simplify the pipeline.
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L90-R95): Added steps to configure the NPM token and verify it before publishing the package.
**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
