### PR TITLE
Re enable bot restriction and add .nojekyll for github pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,9 @@ jobs:
 
             echo "Committing changes=bot(ci): generate token list"
             git commit -m "bot(ci): generate token list"
-
+          environment: # this is needed to avoid misuse of the github token and to avoid leaking secrets by mistake with custom commands
+            NPM_TOKEN: nada
+            GITHUB_TOKEN_GOVERNANCE: nada
       - run:
           name: Add version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
     machine:
       image: ubuntu-2204:2024.08.1
     steps:
+      - continue-if-not-bot
       - setup
       - run:
           name: Prepare git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,6 @@ jobs:
             echo "Committing changes=bot(ci): generate token list"
             git commit -m "bot(ci): generate token list"
 
-          environment: # this is needed to avoid misuse of the github token and to avoid leaking secrets by mistake with custom commands
-            NPM_TOKEN: nada
-            GITHUB_TOKEN_GOVERNANCE: nada
       - run:
           name: Add version
           command: |
@@ -88,16 +85,11 @@ jobs:
             echo "Pushing changes"
             git push "https://x-access-token:${GITHUB_TOKEN_GOVERNANCE}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" $CIRCLE_BRANCH
       - run:
-          name: Configure NPM Token and Registry
-          command: |
-            npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-      - run:
           name: Verify NPM Token
           command: npm whoami
       - run:
           name: Publish package
           command: pnpm publish
-
 
   stale:
       machine:

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-//registry.npmjs.org/:_authToken=$NPM_TOKEN
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 @eth-optimism:registry=https://registry.npmjs.org/
 always-auth=true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request includes several changes to the `.circleci/config.yml` and `.npmrc` files to improve the CI/CD pipeline and token handling. The most important changes include adding a step to continue if not a bot, removing unnecessary NPM token configuration, and modifying the `.npmrc` file to use a different token syntax.

Improvements to CI/CD pipeline:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R45): Added a step to continue the process if the user is not a bot.
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L89-L100): Removed the unnecessary NPM token configuration step to streamline the pipeline.

Token handling:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L75): Removed an empty line after the git commit command to improve readability.
* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deL1-R1): Modified the NPM token syntax to use `${NPM_TOKEN}` instead of `$NPM_TOKEN` for consistency.

Add .nojekill to tell github this does not require to use github actions for building the static website.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
