### PR TITLE
celo: Use WBTC with correct decimals

### DIFF
--- a/data/WBTC/data.json
+++ b/data/WBTC/data.json
@@ -22,7 +22,7 @@
       "address": "0x927B51f251480a681271180DA4de28D44EC4AfB8"
     },
     "celo": {
-      "address": "0xE79a3d9f18C20c93DbEc8db8B28C6542d63df5E9"
+      "address": "0x8aC2901Dd8A1F17a1A4768A6bA4C3751e3995B2D"
     }
   }
 }


### PR DESCRIPTION
**Description**

We wrongly deployed the Celo L2 WBTC token with 16 instead of 8 decimals.
This PR updates to a correct token with 8 decimals.

The old token was only used by me for testing: https://celoscan.io/address/0xE79a3d9f18C20c93DbEc8db8B28C6542d63df5E9