### PR TITLE
fix: handle special characters in token filenames

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,10 +142,11 @@ jobs:
           name: Get changed files and extract tokens
           command: |
             git fetch origin master
-            CHANGED_FILES=$(git diff --name-only origin/master...HEAD -- data/)
+            # -z prints path verbatim and is needed to handle special characters in file names (e.g. USD₮0)
+            CHANGED_FILES=$(git diff --name-only origin/master...HEAD -z -- data/ | tr '\0' '\n')
             tokens=""
             for file in $CHANGED_FILES; do
-              token=$(echo -e "$file" | sed -nr "s|^data/([^/]*/?).*|\1|p")
+              token=$(echo -e "$file" | sed -nr "s|^data/([^/]*)/.*|\1|p")
               if [ ! -z "$token" ]; then
                 tokens+="${token},"
               fi

--- a/data/USD₮0/data.json
+++ b/data/USD₮0/data.json
@@ -3,6 +3,7 @@
   "symbol": "USD₮0",
   "decimals": 6,
   "description": "USD₮0 is the omnichain deployment of USDT.",
+  "nobridge": true,
   "website": "https://usdt0.to/",
   "twitter": "@USDT0_to",
   "tokens": {

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -43,21 +43,21 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     ),
     layer: 2,
   },
-  'redstone': {
+  redstone: {
     id: 690,
     name: 'Redstone',
     provider: new ethers.providers.StaticJsonRpcProvider(
       'https://rpc.redstonechain.com'
     ),
-    layer: 2
+    layer: 2,
   },
-  'metall2': {
+  metall2: {
     id: 1750,
     name: 'Metal L2',
     provider: new ethers.providers.StaticJsonRpcProvider(
       'https://rpc.metall2.com'
     ),
-    layer: 2
+    layer: 2,
   },
   unichain: {
     id: 130,
@@ -65,7 +65,7 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     provider: new ethers.providers.StaticJsonRpcProvider(
       'https://mainnet.unichain.org'
     ),
-    layer: 2
+    layer: 2,
   },
   soneium: {
     id: 1868,
@@ -123,7 +123,7 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     provider: new ethers.providers.StaticJsonRpcProvider(
       'https://sepolia.unichain.org'
     ),
-    layer: 2
+    layer: 2,
   },
   'soneium-minato': {
     id: 1946,
@@ -133,7 +133,7 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     ),
     layer: 2,
   },
-  'celo': {
+  celo: {
     id: 42220,
     name: 'Celo',
     provider: new ethers.providers.StaticJsonRpcProvider(
@@ -141,7 +141,7 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     ),
     layer: 2,
   },
-  'swellchain': {
+  swellchain: {
     id: 1923,
     name: 'Swellchain',
     provider: new ethers.providers.StaticJsonRpcProvider(
@@ -149,7 +149,7 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     ),
     layer: 2,
   },
-  'ink': {
+  ink: {
     id: 57073,
     name: 'Ink',
     provider: new ethers.providers.StaticJsonRpcProvider(
@@ -165,7 +165,7 @@ export const NETWORK_DATA: Record<Chain, Network> = {
     ),
     layer: 2,
   },
-  'worldchain': {
+  worldchain: {
     id: 480,
     name: 'Worldchain',
     provider: new ethers.providers.StaticJsonRpcProvider(
@@ -211,10 +211,10 @@ export const L2_STANDARD_BRIDGE_INFORMATION: Record<
   unichain: {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
-  'redstone': {
-    l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010'
+  redstone: {
+    l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
-  'metall2': {
+  metall2: {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
   soneium: {
@@ -238,19 +238,19 @@ export const L2_STANDARD_BRIDGE_INFORMATION: Record<
   'soneium-minato': {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
-  'celo': {
+  celo: {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
-  'swellchain': {
+  swellchain: {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
-  'ink': {
+  ink: {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
   'ink-sepolia': {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
-  'worldchain': {
+  worldchain: {
     l2StandardBridgeAddress: '0x4200000000000000000000000000000000000010',
   },
   'worldchain-sepolia': {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -48,7 +48,9 @@ export const generate = (datadir: string) => {
           name: token.overrides?.name ?? data.name,
           symbol: token.overrides?.symbol ?? data.symbol,
           decimals: token.overrides?.decimals ?? data.decimals,
-          logoURI: `${BASE_URL}/data/${folder}/logo.${logoext}`,
+          logoURI: `${BASE_URL}/data/${encodeURIComponent(
+            folder
+          )}/logo.${logoext}`,
           extensions: {
             ...bridges,
             opListId: defaultTokenDataFolders.has(folder.toUpperCase())

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,3 +1,5 @@
+import { NETWORK_DATA } from './chains'
+
 export const ADDRESS_TYPE = {
   type: 'string',
   minLength: 42,
@@ -59,22 +61,13 @@ export const TOKEN_DATA_SCHEMA = {
     tokens: {
       type: 'object',
       properties: {
-        ethereum: TOKEN_SCHEMA,
-        optimism: TOKEN_SCHEMA,
-        base: TOKEN_SCHEMA,
-        lisk: TOKEN_SCHEMA,
-        mode: TOKEN_SCHEMA,
-        unichain: TOKEN_SCHEMA,
-        redstone: TOKEN_SCHEMA,
-        metall2: TOKEN_SCHEMA,
-        soneium: TOKEN_SCHEMA,
-        sepolia: TOKEN_SCHEMA,
-        'base-sepolia': TOKEN_SCHEMA,
-        'optimism-sepolia': TOKEN_SCHEMA,
-        'lisk-sepolia': TOKEN_SCHEMA,
-        'metall2-sepolia': TOKEN_SCHEMA,
-        'unichain-sepolia': TOKEN_SCHEMA,
-        'soneium-minato': TOKEN_SCHEMA,
+        ...Object.keys(NETWORK_DATA).reduce(
+          (acc, chain) => ({
+            ...acc,
+            [chain]: TOKEN_SCHEMA,
+          }),
+          {}
+        ),
       },
       additionalProperties: false,
       anyOf: [


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ethereum-optimism.github.io/issues/1141

This PR contains a few changes to get validation working again:
- Encode the token symbol part of the `logoURI` in order to avoid failures when token symbols contain characters that do not pass uri validation: ([example](https://circleci-tasks-prod.s3.us-east-1.amazonaws.com/forks/storage/artifacts/333b3b63-b6a9-4616-b483-d8a655eafa6c/934993580/782a4c86-a600-4555-b7ba-9c636a2804c4/0/validation_results.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Checksum-Mode=ENABLED&X-Amz-Credential=ASIAQVFQINEON5Y2P3QV%2F20250513%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250513T203015Z&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEE0aCXVzLWVhc3QtMSJIMEYCIQCFJXne60CXIzjMC2LZ%2BrkDA6fu6uWvuoxe8tUzaUQ%2BawIhALIN4HTjVMYvj%2B1pD9jTMNsxBCateNDABla2FinKD6IoKrQCCPb%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQAxoMMDQ1NDY2ODA2NTU2IgzOE%2B6r%2FB0%2BrPK7sUcqiALcvmOHNxdGuNdgG%2FBRddAiJEU0eLEc8JjHKoLhJ8U8W5xpz5bRl09bPo1SleC6TQp%2BM0j6SIoLai08y1%2BLDH0ObDsQfF%2B026BGXgb8gjiGTQ1RslRcvTJFnML34%2Fb5VSxfDXfy90zIoAPg6vw%2FvVrgA382D7hpzj%2BTWIeBTMAGaHbzxvpAsI%2BrjcBrb9VldN77ekTr1pqPcryLE1g%2FcK4%2B%2BY6kzA%2B5DKUrwCe1e9T96ARJiFTu9isfNOVhOSVhI1JSgi2I0s4H5tngdE5pmlNaffIxujwQ7CDrw%2FcXCVAVD10a03H%2B4DNW7NpvotJNBfwa7qyYKzxuriyNUk7V%2Bba0ATXtnWWjHNkwo9WOwQY6nAGgGXUR92QdpnpcK%2FtyZjGbEkZRZDGwvpTieK%2FkZOn5Yfg6pR1PG9qTV3OxlOrvmB1neZruU9Eq%2FeQCX3S1y2h8dUgD9six12ra5ZWqyQrdnQEz0JvL8sozapNl1McgH2aJAtzEO6Nye3cnjWxMx5EeKfeGF0VkhVKpOI3cN%2FGGXvT18bvCPBkzibpLXgH0N4WdMnBMTliW16bLcCg%3D&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=b5a7386cd69c08d467f609f24543acd2d2a1496c5a8c9f7281a4e4b2ba067055) where USD₮0 failed validation)
- Update the validate ci job to pass the `-z` flag in the `git diff` command when fetching changed files so that the pathname is printed verbatim and token symbols with special characters (e.g. `USD₮0`) are not escaped.
- Update the regex for parsing the token symbol to correctly parse the token symbol. Without this change it parses `data/ETH/data.json` as `ETH/`, when it should parse as `ETH`
- Adds all chains to `TOKEN_DATA_SCHEMA`

