### PR TITLE
Fix missing dist directory in published npm package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,11 @@ jobs:
             echo "Pushing changes"
             git push "https://x-access-token:${GITHUB_TOKEN_GOVERNANCE}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" $CIRCLE_BRANCH
       - run:
+          name: Build package
+          command: |
+            # build the dist directory for publishing
+            pnpm tsup --dts
+      - run:
           name: Verify NPM Token
           command: npm whoami
       - run:

--- a/optimism.tokenlist.json
+++ b/optimism.tokenlist.json
@@ -6,7 +6,7 @@
     "layer2",
     "infrastructure"
   ],
-  "timestamp": "2025-06-13T18:46:31.449Z",
+  "timestamp": "2025-06-13T18:53:20.584Z",
   "tokens": [
     {
       "chainId": 1,
@@ -14167,6 +14167,6 @@
   "version": {
     "major": 10,
     "minor": 0,
-    "patch": 1696
+    "patch": 1697
   }
 }


### PR DESCRIPTION
### Problem
Versions after 10.0.238 of `@eth-optimism/tokenlist` do not include a `dist` directory, resulting in the following error when attempting to import the package:

```
Module not found: Can't resolve '@eth-optimism/tokenlist'
```

### Root Cause
The CircleCI publish workflow was missing a critical build step. While the workflow correctly:
1. Generated the token list (`pnpm generate:ci`)
2. Bumped the version and committed changes
3. Published the package (`pnpm publish`)

It was **not** building the `dist` directory that contains the compiled JavaScript and TypeScript declaration files that consumers need to import the package.

The `package.json` correctly specifies:
- `"main": "dist/index.js"`
- `"module": "dist/index.mjs"` 
- `"types": "dist/index.d.ts"`
- `"files": ["dist"]`

But without the build step, the `dist` directory didn't exist in the published package.

### Solution
Added a build step in the CircleCI workflow before publishing:

```yaml
- run:
    name: Build package
    command: |
      # build the dist directory for publishing
      pnpm tsup --dts
```

This ensures the `dist` directory is created with all necessary compiled files before the package is published to npm.

### Verification
- Ran `npm pack --dry-run` to confirm the `dist` directory and all its files are included in the package
- Build process successfully creates all required files:
  - `index.js`, `index.mjs` (compiled JavaScript)
  - `index.d.ts`, `optimism.tokenlist.d.ts` (TypeScript declarations)
  - Source maps and other build artifacts

### Impact
- ✅ Fixes import errors for `@eth-optimism/tokenlist` package
- ✅ Ensures future published versions include the required `dist` directory
- ✅ No breaking changes - maintains existing API and file structure
- ✅ Aligns CI workflow with the existing `release` script pattern