### PR TITLE
Update Website Link for AJNA

### DIFF
--- a/data/bwAJNA/data.json
+++ b/data/bwAJNA/data.json
@@ -3,7 +3,7 @@
   "symbol": "bwAJNA",
   "decimals": 18,
   "description": "AJNA tokens are the Ajna Protocol's native token. bwAJNA tokens are burn-wrapped on mainnet before traversing L2 bridges. They are bought and burned by pools with excess reserves.",
-  "website": "https://www.ajna.finance/team",
+  "website": "https://www.ajna.finance/",
   "twitter": "@ajnafi",
   "tokens": {
     "ethereum": {


### PR DESCRIPTION
Replaced the broken website link with the main Ajna Finance URL in the data.json file.
This update ensures users can access the main site for more information about AJNA tokens and related services.

<img width="1387" alt="Знімок екрана 2025-06-17 о 18 02 50" src="https://github.com/user-attachments/assets/7f64d399-14e9-4ecb-9845-75046df581ef" />
