### PR TITLE
fix: update Optimism testnet reference link

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface Token {
  * Supported chains for the tokenlist
  * If adding a new chain consider keeping the name
  * consistent with wagmi
- * @see https://github.com/wagmi-dev/references/blob/main/packages/chains/src/optimismGoerli.ts
+ * @see https://github.com/wevm/viem/blob/main/src/chains/definitions/optimismSepolia.ts
  */
 export type Chain =
   | 'ethereum'


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Replace deprecated OptimismGoerli link with working OptimismSepolia link
