### PR TITLE
Settle WIT addresses on Ethereum and Base

### DIFF
--- a/data/WIT/data.json
+++ b/data/WIT/data.json
@@ -26,6 +26,20 @@
       "overrides": {
         "bridge": "0x4200000000000000000000000000000028"
       }
+    },
+    "ethereum": {
+      "address": "0xcafe5De18756817D98F4603F6828397406D4CaFE",
+      "overrides": {
+        "bridge": {
+          "base": "0x4200000000000000000000000000000010"
+        }
+      }
+    },
+    "base": {
+      "address": "0xcafe5De18756817D98F4603F6828397406D4CaFE",
+      "overrides": {
+        "bridge": "0x4200000000000000000000000000000010"
+      }
     }
   }
 }


### PR DESCRIPTION
Settle the Witnet token address in Ethereum and Base:

**Token Details**:
- 
Name: Witnet
- Symbol: WIT
- Decimals: 9
- Description: _"ERC-20 representation of $WIT, the native coin securing the Witnet oracle network — a fully decentralized, permissionless protocol for trustless retrieval, verification, and delivery of real-world data into smart contracts."_
- Website: https://witnet.io
- Website: https://witnet.io
- Github repo: https://github.com/witnet/witnet-wrapped-wit.
- Address: `0xcafe5De18756817D98F4603F6828397406D4CaFE`

Notes:
- Ethereum is the only mainnet where native WIT can be wrapped and unwrapped from/into the Witnet mainnet.
- The Base address implements `IOptimismMintableERC20 `, accepting `0x42...10` as bridge operator.
