### PR TITLE
Adding OLAS token to Mode

### DIFF
--- a/data/OLAS/data.json
+++ b/data/OLAS/data.json
@@ -17,6 +17,9 @@
     },
     "celo": {
       "address": "0xD80533CA29fF6F033a0b55732Ed792af9Fbb381E"
+    },
+    "mode": {
+      "address": "0xcfD1D50ce23C46D3Cf6407487B2F8934e96DC8f9"
     }
   }
 }


### PR DESCRIPTION
**Description**

Add existing OLAS token to Mode network.
Token Ethereum mainnet address: https://etherscan.io/address/0x0001A500A6B18995B03f44bb040A5fFc28E45CB0
Token Mode mainnet address: https://explorer.mode.network/address/0xcfD1D50ce23C46D3Cf6407487B2F8934e96DC8f9

**Tests**

Tests are not provided as the contract has been deployed by the [OptimismMintableERC20Factory](https://explorer.mode.network/address/0x4200000000000000000000000000000000000012).

**Additional context**

No additional context.

**Metadata**

N/A
