### PR TITLE
chore: update Node.js version and modify CI configuration for npm trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
             pnpm tsup --dts
       - run:
           name: Install npm with OIDC trusted publishing support
-          command: npm install -g npm@latest
+          command: npm install -g npm@11.12.1
       - run:
           name: Obtain OIDC token for npm trusted publishing
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,11 +101,15 @@ jobs:
             # build the dist directory for publishing
             pnpm tsup --dts
       - run:
-          name: Verify NPM Token
-          command: npm whoami
+          name: Install npm with OIDC trusted publishing support
+          command: npm install -g npm@latest
+      - run:
+          name: Obtain OIDC token for npm trusted publishing
+          command: |
+            echo "export NPM_ID_TOKEN=$(circleci run oidc get --claims '{\"aud\": \"npm:registry.npmjs.org\"}')" >> "$BASH_ENV"
       - run:
           name: Publish package
-          command: pnpm publish
+          command: npm publish
 
   stale:
       machine:
@@ -209,7 +213,7 @@ workflows:
             branches:
               only: master
       - generate-token-list-and-publish:
-          context: circleci-repo-ethereum-optimism.github.io
+          context: circleci-repo-ethereum-optimism.github.io # for GITHUB_TOKEN_GOVERNANCE
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,14 @@ jobs:
       - run:
           name: Obtain OIDC token for npm trusted publishing
           command: |
-            echo "export NPM_ID_TOKEN=$(circleci run oidc get --claims '{\"aud\": \"npm:registry.npmjs.org\"}')" >> "$BASH_ENV"
+            set -e
+            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud":"npm:registry.npmjs.org"}')
+            if [ -z "$NPM_ID_TOKEN" ]; then
+              echo "ERROR: circleci run oidc get returned an empty token" >&2
+              exit 1
+            fi
+            echo "OIDC token fetched (length=${#NPM_ID_TOKEN})"
+            echo "export NPM_ID_TOKEN=$NPM_ID_TOKEN" >> "$BASH_ENV"
       - run:
           name: Publish package
           command: npm publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 @eth-optimism:registry=https://registry.npmjs.org/
-always-auth=true

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "18.18.0"
+node = "22.14.0"
 
 [hooks]
 # Enabling corepack will install the `pnpm` package manager specified in package.json


### PR DESCRIPTION
This pull request updates the Node.js version, transitions the npm publishing workflow to use OIDC (OpenID Connect) for authentication, and removes the use of static npm tokens. These changes improve security and modernize the CI/CD process for publishing npm packages.

**CI/CD and Publishing Workflow Improvements:**

* Updated the npm publishing process in `.circleci/config.yml` to use OIDC trusted publishing instead of static npm tokens, including installing a newer npm version and obtaining an OIDC token for authentication.
* Changed the `publish` command to use `npm publish` instead of `pnpm publish` to align with OIDC trusted publishing requirements.
* Removed the use of the `NPM_TOKEN` environment variable in `.npmrc`, eliminating static token-based authentication in favor of OIDC.

**Dependency and Environment Updates:**

* Upgraded the Node.js version in `mise.toml` from `18.18.0` to `22.14.0` to ensure compatibility with the latest npm features required for OIDC.

**Other Configuration Adjustments:**

* Added a clarifying comment in the CircleCI workflow context for `generate-token-list-and-publish` to indicate the use of `GITHUB_TOKEN_GOVERNANCE`.