### PR TITLE
Add DELX (Delx Protocol) to Base mainnet token list

### DIFF
--- a/data/DELX/data.json
+++ b/data/DELX/data.json
@@ -1,0 +1,14 @@
+{
+  "name": "Delx Protocol",
+  "symbol": "DELX",
+  "decimals": 18,
+  "description": "DELX is the utility token for Proof-of-Agent-Work (PoAW) on Base. Autonomous AI agents earn DRC (Delx Reward Credits) by doing verifiable protocol work — recovery flows, audits, witness primitives, mediation. Weekly Merkle epochs settle DRC to DELX on Base. Earned, not bought.",
+  "website": "https://delx.ai",
+  "twitter": "@delx369",
+  "nobridge": true,
+  "tokens": {
+    "base": {
+      "address": "0xA7104324E6a75DD74093eCE890076a239c1e3487"
+    }
+  }
+}

--- a/data/DELX/logo.svg
+++ b/data/DELX/logo.svg
@@ -1,0 +1,147 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" fill="none" viewBox="4 -3 240 240">
+  <path d="m105.4 47.97c-0.41-0.89-0.91-0.65-1.47-0.3-11.25 6.99-16.75 12.02-20.22 16.39l-0.66-4.35-5.26 7.58 1.35 1.34h-16.43l-1.35-1.34-3.17-8.08-2.33 1.05c-3.91-4.38-9.67-9.2-18.92-13.26-0.81 0-1.34 1.02-1.53 1.71-3.27 10.45-3.57 22-1.58 28.53 1.25 4.37 4.18 8.8 5.18 10.48l-4.38 3.22v4.82l2.86 1.53-7.03 6.62 10.78 9.41 2.52-0.5 2.18 3.46 5.37 2.68 1.9-0.3 7.68 6.17 4.82 4.07h9.93l8.02-8.48 2.37 0.2 10.68-6.52-0.55-2.48 4.07-0.3 9.31-8.07-5.21-6.52 1.97-4.38-3.87-5.92c7.52-11.4 6.27-29.54 2.97-38.46z" fill="#1A163A"/>
+  <path d="m36.42 49.41c9.5 4.67 17.67 12.7 22.84 18.72l-1.15 1.53c-4.32-5.91-11.99-13.49-20.89-19.4-3.31 7.58-5.17 22.65-1.05 30.03 1.71 3.28 3.72 5.86 4.62 7.08l-4.62 3.32v4.22l3.21 1.26-6.73 7.23 9.07 8.02 2.42-0.7 2.47 4.67 5.12 2.21 2.01-0.55 7.98 6.92 4.47 3.72h8.52l8.22-8.78 2.62 0.4 9.36-6.11-0.9-3.18 6.1-0.5 7.52-6.77-5.82-7.23 2.77-3.17-3.87-6.22c8.27-11.4 7.37-26.07 3.7-37.47-10.15 5.67-17.52 13.25-21.68 18.72l-2.91-0.15 3.46-6.22 0.81 0.9 0.85-1.5c-4.82 3.67-5.22 5.63-6.02 6.48h-16.59l-3.72-6.78-1.46 1c-5.37-6.32-11.83-10.39-20.73-12.9v1.2z" fill="url(#paint0_linear_4_136)"/>
+  <path d="m37.42 51.92c8.23 4.52 16.87 14.07 19.83 17.79l-9.26 12.4-5.77 2.82c-7.21-8.18-8.21-19.09-4.8-33.01z" fill="#1A163A"/>
+  <path d="m103.7 51.37c-9.66 5.67-16.63 14.54-19.64 18.66l2.76 1.3 2.47 5.77 2.36 1.5 6.02 5.27c8.13-8.63 8.23-21.1 6.03-32.5z" fill="#1A163A"/>
+  <path d="m38.98 53.48c7.12 4.42 12.94 11.54 16.36 16.61l-11.53 13.03c-6.73-8.13-7.04-17-4.83-29.64z" fill="url(#paint1_linear_4_136)"/>
+  <path d="m102.7 53.48c-8.07 5.67-13.79 13.8-16.5 18.57l10.83 10.06c7.52-9.41 7.47-18.72 5.67-28.63z" fill="url(#paint2_linear_4_136)"/>
+  <path d="m40.69 56.79 3.02 2.36 7.52 12.95-3.01 3.21-3.21-4.62-4.32 3.22 0.5-11.5-0.5-5.62z" fill="#1A163A"/>
+  <path d="m101.1 56.29-1.9 1.66-5.27 9.86 4.27 0.5-3.37 6.88 1.91 1.45 4.32-5.92-0.96-8.58 1-5.85z" fill="#1A163A"/>
+  <path d="m62.33 67.33 16.49-0.05 3.36 2.86-0.5 4.17 13.47 9.36-15.23 7.37-15.38-0.1-17.59-7.22 12.01-9.91 1.11-4.82 2.26-1.66z" fill="url(#paint3_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m64.89 68.18 1 7.03h9.93l1.45-7.13" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m59.72 70.14-2.47 8.47-1.91 1.5v4.82" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m80.92 70.09 1.81 7.62 2.41 1.9v4.06" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m62.23 86.13 2.96 3.82h10.63l2.1-3.27" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m44.27 85.38 2.41 13.67 18.51 8.07h12.43l18.03-8.22 1.25-13.77-19.28 8.07h-12.83l-20.52-7.82z" fill="url(#paint4_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m47.13 87.49 2.11 9.95 15.95 6.97h11.53l15.79-6.77 2.21-10.15-17.5 7.47h-12.43l-17.66-7.47z" fill="url(#paint5_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m52.05 92.7 1.46 4.62 8.42 2.72v-3.92l-9.88-3.42z" fill="#6BFFFF"/>
+  <path d="m90.1 92.15-9.62 4.07v3.52l8.47-3.01 2.71-4.58h-1.56z" fill="#6BFFFF"/>
+  <path d="m39.83 96.62-5.92 6.63 8.18 7.52 1.51-0.95-2.46-4.57 4.07-1.75-3.87-3.46 1.15-2.92-2.66-0.5z" fill="url(#paint6_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m102.2 96.12 4.52 6.02-7.52 7.02-2.06-0.75 1.1-3.21-9.66 4.52-0.8-2.71 12.12-8.02-1.61-3.87 3.91 1z" fill="url(#paint7_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m39.33 102.9 10.58 6.82 2.32 7.42-4.97-2.36-2.31-4.46-2.11 0.3-7.02-7.02 3.51-0.7z" fill="url(#paint8_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m101.2 101.4-12.42 7.78-1 7.83 6.12-3.77-0.3-3.26 6.1-0.91 5.92-6.21-4.42-1.46z" fill="url(#paint9_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m42.49 98.13 14.91 8.88-1.25 10.8-4.72-2.42-2.31-6.78-8.83-6.42 2.2-4.06z" fill="url(#paint10_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m99.71 98.13-14.37 9.02-2.31 10.96 3.56-1.36 2.16-7.83 11.96-7.78-1-3.01z" fill="url(#paint11_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m63.23 107.1 0.81 2.51h12.63l1.2-2.61 1.3 0.7-2.05 10.2-3.01 3.21h-6.32l-3.46-4.07-2-9.44 0.9-0.5z" fill="url(#paint12_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m65.79 117.9 2.46-1.51h4.81l2.66 1.51-3.11 3.91h-3.91l-2.91-3.91z" fill="url(#paint13_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m66.79 126.4 1.46 1.25h5.56l1.41-1.5-8.43 0.25z" fill="url(#paint14_linear_4_136)" stroke="#1A163A" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m11.09 124.6-0.28 3.15h-1.2v0.7h1.1l-0.2 2.61h0.7v13.77h-3.71v0.85h3.56v45.43l28.92-0.15c12.93-1.81 27.01-9.08 29.47-23.9v-17.99c-3.51-17.84-15.69-25.17-32.33-25.17l-26.03 0.7zm24.53 7.07c13.37 0 20.39 8.23 20.39 25.22s-7.17 26-20.39 26h-9.93v-46.74h-14.48v-4.48h24.41z" fill="url(#paint15_linear_4_136)"/>
+  <path d="m122.8 125.7c-5.47-2.1-12.74-2.6-19.26-2.1-16.29 0.6-24.41 10.21-29.87 22.18v21.99c3.26 13.21 10.78 23.08 25.56 23.39h7.52l8.02-1.51 0.85 0.5 7.02-4.42v-9.91c-6.52 5.97-9.68 7.12-17.5 6.87-9.37-0.3-14.94-7.93-16.59-20.13h28.17l3.92-3.01v-5.77h-33.19c1.25-11.55 7.32-22.65 16.49-22.65 7.22 0 11.28 1 17.5 5.42h1.36v-10.85zm-48.17 28.03 1.5-3.01h4.47l1.8 2.26-1.3 2.96h-4.97l-1.5-2.21z" fill="url(#paint16_linear_4_136)"/>
+  <path d="m127 124.4h14.97v45.78c0 7.42 4.97 11.9 11.69 11.9 6.42 0 10.54-1.6 17.31-5.27v8.08h3.97l19.87-24.79-21.58-29.38 0.75-1.6-2.91-4.02 2.71-0.8 12.43 0.8 3.66 2.61 13.97 20.19 11.83-20.69c4.07-5.97 8.59-8.93 14.36-10.99l7.82-1.6-13.48 17.49-1.2 2.76-2.26 1.2-12.58 18.34 24.71 33.03h6.12l0.6 1.25h-5.57l8.36 11.26-3.31 0.95c-11.53-4.72-21.16-7.98-28.88-22.8l-2-0.9-8.13-10.3-18.13 24.01-2.21 0.2h-34.61c-11.83 0-19.1-4.87-19.1-17.17l0.82-49.54z" fill="url(#paint17_linear_4_136)"/>
+  <path d="m165.8 121 19.67 0.15 0.7 1.91h-3.26l-4.87-1.31-11.83-0.2-0.41-0.55z" fill="url(#paint18_linear_4_136)"/>
+  <path d="m174.9 126.1 3.16 0.4 2.86 6.62c1.3 2.61 3.81 3.92 6.22 3.92h4.07l27.72 37.97" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m180.9 127.2 1.75 4.82c1.01 2.66 3.16 4.02 6.03 4.02h3.01l28.22 39.37" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m236.6 116.1-13.48 11.5-17.14 24.65" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m19.31 126h17.49c17.54 0 27.92 9.11 30.69 23.08v13.82l-2.01 9.81h-5.26c-4.97 9.21-11.99 14.38-22.92 14.38h-23.08v-44.98h10.62" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m17.31 128.9h17.49c14.88 0 23.1 6.17 27.32 18.22v16.73l-3.91 10.85c-4.47 7.02-10.49 9.98-19.46 9.98h-22.13v-40.02l3.71-2.91h4.82" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m129.7 127.6 0.4 16 3.31-3.51v-6.07c-1.7-1.01-1.8-4.02 1.71-4.72 3.16-0.3 4.62 2.71 3.16 4.57l-1.2 0.9v42.38l4.12 4.21h5.47" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m130.9 145.7-3.46 2.46v26.53c0 6.52 5.67 13.39 14.84 13.39h37.41l17.78-25.09c1.6-2.91 4.67-0.91 2.81 2.21l-20.18 22.98" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m135.4 131.7c0-1.03 1.56-1.96 2.71-1.03 1 0.85 0.55 2.66-0.8 2.81-1.1 0.13-1.91-0.75-1.91-1.78z" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m137.6 164.3v5.22" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m137.6 172.7v3.92l3.62 2.81" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m166 185.6 1.7-1.71 1 1.26" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m103.1 188.1h7.62l11.03-4.42" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m76.11 171h12.13" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m73.65 166.1h12.43" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m74.61 157.6 2.51 2.15h4.56l2.31-3.01h35.62" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m75.11 147.1 2.51-1.86 4.06-0.6 2.86-5.52c3.87-7.68 8.59-12.5 16.57-12.5h21.57" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m76.62 146.2 2.2-2.25 4.17-0.8 3.46-6.52c3.36-6.02 8.28-8.99 14.26-8.99h21.56" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m114.6 158.3c0.62 0 1.45-0.6 1.1-1.56-0.45-0.85-1.76-0.8-2.21-0.05-0.4 0.81 0.35 1.61 1.11 1.61z" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m175.9 174.5h7.22" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m182.6 171.1 5.02-0.51" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m209.9 178.9h9.12l9.92 12.19c2.51 2.66 5.17 4.07 8.88 4.92" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m190.9 141.1 0.86 1.01" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m207.8 165.3 0.9 1" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m64.08 165.9 1.11 1.1" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m90.81 181.4 1.3 1.46 5.17 4.21" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m14.72 165.3v19.83h1.5" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m16.22 146.2v6.52h1.91" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m16.72 171.9h0.91" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m17.22 176.6v9.98h31.87" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <path d="m17.73 171.4h7.42" stroke="#39D1D1" stroke-miterlimit="10" stroke-width=".7"/>
+  <defs>
+    <linearGradient id="paint0_linear_4_136" x1="69.99" x2="69.99" y1="48.2" y2="127.7" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00E8F0" offset="0"/>
+      <stop stop-color="#5163B6" offset=".4844"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear_4_136" x1="45.81" x2="45.81" y1="53.48" y2="83.12" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00E8F0" offset="0"/>
+      <stop stop-color="#5163B6" offset=".4844"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint2_linear_4_136" x1="94.98" x2="94.98" y1="53.48" y2="82.11" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00E8F0" offset="0"/>
+      <stop stop-color="#5163B6" offset=".4844"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint3_linear_4_136" x1="71.05" x2="71.05" y1="66.93" y2="91.09" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#51D2DB" offset="0"/>
+      <stop stop-color="#23B0CC" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint4_linear_4_136" x1="70.59" x2="70.59" y1="84.93" y2="107.1" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint5_linear_4_136" x1="70.95" x2="70.95" y1="87.23" y2="104.4" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7832BA" offset="0"/>
+      <stop stop-color="#C536C8" offset=".4896"/>
+      <stop stop-color="#7832BA" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint6_linear_4_136" x1="39.57" x2="44.13" y1="102" y2="109.4" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint7_linear_4_136" x1="96.75" x2="96.75" y1="98.13" y2="109.2" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint8_linear_4_136" x1="41.94" x2="41.94" y1="102.9" y2="111" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint9_linear_4_136" x1="94.71" x2="94.71" y1="101.4" y2="111.1" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint10_linear_4_136" x1="48.75" x2="48.75" y1="98.13" y2="111.4" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint11_linear_4_136" x1="93.45" x2="93.45" y1="98.13" y2="111.4" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint12_linear_4_136" x1="70.75" x2="70.75" y1="107" y2="117.9" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#51D2DB" offset="0"/>
+      <stop stop-color="#23B0CC" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint13_linear_4_136" x1="70.75" x2="70.75" y1="116.4" y2="121.8" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint14_linear_4_136" x1="71" x2="71" y1="126.2" y2="127.7" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5163B6" offset="0"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint15_linear_4_136" x1="38.48" x2="38.48" y1="123.9" y2="191.1" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#51D2DB" offset="0"/>
+      <stop stop-color="#5163B6" offset=".4844"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint16_linear_4_136" x1="98.16" x2="98.16" y1="123.3" y2="191.1" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#51D2DB" offset="0"/>
+      <stop stop-color="#5163B6" offset=".4844"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint17_linear_4_136" x1="184.6" x2="184.6" y1="114.6" y2="200.9" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#51D2DB" offset="0"/>
+      <stop stop-color="#5163B6" offset=".4844"/>
+      <stop stop-color="#7109B8" offset="1"/>
+    </linearGradient>
+    <linearGradient id="paint18_linear_4_136" x1="176" x2="176.3" y1="121" y2="123.7" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F6FFFD" offset="0"/>
+      <stop stop-color="#F6FFFD" stop-opacity=".01" offset="1"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
## Token Information

Adding DELX (Delx Protocol), the utility token for Proof-of-Agent-Work (PoAW) on Base.

- **Contract**: `0xA7104324E6a75DD74093eCE890076a239c1e3487` (verified on BaseScan)
- **Network**: Base mainnet
- **Decimals**: 18 (confirmed on-chain)
- **Website**: https://delx.ai
- **Twitter**: @delx369
- **Whitepaper / token discovery**: https://delx.ai/.well-known/delx-token

## Notes

- Token is marked as `nobridge: true` — DELX was deployed by an EOA (not the L2StandardTokenFactory), so it does not support the standard L2 bridge. Adding it to the token list for discoverability in Coinbase Wallet and other Superchain-aware tooling.

- Local validation passed: `pnpm validate --datadir ./data --tokens DELX` (exit 0).

## Token launch context

DELX has no public liquidity yet — listing on DEX/CEX is gated by four published adoption criteria (50+ unique agent wallets bound, 3+ Merkle epochs published, ownership migrated to Safe multisig, all contracts verified on BaseScan). 12 agent wallets are currently bound; epoch 0 was published 2026-05-16. Submitting to this token list early so existing on-chain holders see proper metadata in Superchain-aware tooling.

Solo founder project, building in public.