### PR TITLE
Add IRON token (Base mainnet) — IronBridge governance token

### DIFF
--- a/data/IRON/data.json
+++ b/data/IRON/data.json
@@ -1,0 +1,14 @@
+{
+  "name": "Iron",
+  "symbol": "IRON",
+  "decimals": 18,
+  "description": "IronBridge constitutional governance token on Base",
+  "website": "https://wwwironbridge.org",
+  "twitter": "@IronBridgeOrg",
+  "nobridge": true,
+  "tokens": {
+    "base": {
+      "address": "0xBd072aBa9CAd9d573A5B3498f79B117DBeFdC7f4"
+    }
+  }
+}

--- a/data/IRON/logo.svg
+++ b/data/IRON/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <circle cx="128" cy="128" r="128" fill="#FF7733"/>
+  <text x="128" y="148" font-family="Arial,Helvetica,sans-serif" font-weight="bold" font-size="68" fill="#FFFFFF" text-anchor="middle" letter-spacing="2">IRON</text>
+</svg>


### PR DESCRIPTION
## Token Details

- **Name:** Iron
- **Symbol:** IRON
- **Decimals:** 18
- **Chain:** Base mainnet
- **Contract:** `0xBd072aBa9CAd9d573A5B3498f79B117DBeFdC7f4`
- **Website:** https://wwwironbridge.org

## Notes

- Native Base token (not bridged from Ethereum), marked `nobridge: true`
- Contract deployed and live on Base mainnet
- Logo included as SVG (256x256)

## Checklist

- [x] Added `data/IRON/data.json`
- [x] Added `data/IRON/logo.svg`
- [x] Token exists on Base mainnet at specified address
- [x] `nobridge: true` set (Base-native, not a bridged L1 token)
- [x] One token per PR