### PR TITLE
Add SINC token on Base

### DIFF
--- a/data/SINC/data.json
+++ b/data/SINC/data.json
@@ -1,0 +1,14 @@
+{
+  "name": "SINC",
+  "symbol": "SINC",
+  "decimals": 8,
+  "description": "SINC is the utility token of SINCOR, a production AI agent swarm on Base mainnet. Contracts are Sourcify-verified with CertiK Skynet 97/100. Fixed 100M supply, 8 decimals, no mint, no admin keys. SINC powers access to the agent network, curated sales, and on-chain coordination via Uniswap v4 limit-order infrastructure.",
+  "website": "https://getsincor.com",
+  "twitter": "@getsincor",
+  "nobridge": true,
+  "tokens": {
+    "base": {
+      "address": "0x9C8cd8d3961F445D653713dE65C6578bE11668e7"
+    }
+  }
+}

--- a/data/SINC/data.json
+++ b/data/SINC/data.json
@@ -8,7 +8,7 @@
   "nobridge": true,
   "tokens": {
     "base": {
-      "address": "0x9C8cd8d3961F445D653713dE65C6578bE11668e7"
+      "address": "0xe1D836087F6573b665d25CE088793E916D7892f8"
     }
   }
 }

--- a/data/SINC/logo.svg
+++ b/data/SINC/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <image href="https://getsincor.com/static/tokenlists/assets/logo-256.png" width="256" height="256"/>
+</svg>


### PR DESCRIPTION
Adds SINC (0xe1D836087F6573b665d25CE088793E916D7892f8)  on Base mainnet.

- Native Base ERC-20 (nobridge: true)
- Website: https://getsincor.com
- Sourcify full-match verified contracts
- CertiK Skynet 97/100
- Fixed 100M supply, 8 decimals, no mint/admin keys

