### PR TITLE
Add Base T token

### DIFF
--- a/data/T/data.json
+++ b/data/T/data.json
@@ -14,6 +14,9 @@
     },
     "unichain": {
       "address": "0x8F43Ab8648F1a3BAEea3782Ba5f562a148f2Ad54"
+    },
+    "base": {
+      "address": "0x26f3901ac8a79c50fb0d8289c74f0d09adc42e29"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the Base deployment for Threshold Network Token (`T`) to the Superchain token metadata.

## Details

- Ethereum `T`: `0xCdF7028ceAB81fA0C6971208e83fa7872994beE5`
- Base `T`: `0x26f3901ac8a79c50fb0d8289c74f0d09adc42e29`
- The Base token is an `OptimismMintableERC20` using the standard Base bridge at `0x4200000000000000000000000000000000000010`.
- The Base token's `remoteToken()` / `l1Token()` points back to the Ethereum `T` token above.

## Validation

```sh
pnpm validate --datadir ./data --tokens T
```

This completed successfully locally.
