### PR TITLE
Add THSND (Thousand) on Base

### DIFF
--- a/data/THSND/data.json
+++ b/data/THSND/data.json
@@ -1,0 +1,1 @@
+{"name":"Thousand","symbol":"THSND","decimals":18,"description":"Thousand ($THSND): 1 billion minted at launch on Base, no way to mint more, burns shrink it forever. Vault pays lockers real WETH fees.","website":"https://thsnd.xyz","nobridge":true,"tokens":{"base":{"address":"0xF7aa829ed31fE30834E56348e9CD3fBb4687CFdb"}}}

--- a/data/THSND/logo.svg
+++ b/data/THSND/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256"><rect width="256" height="256" fill="#000000"/><g fill="#FFFFFF" fill-rule="evenodd"><rect x="28" y="90" width="18" height="76"/><path d="M66 107h41v42H66zM77 118v20h19v-20z"/><path d="M126 107h42v42h-42zM137 118v20h20v-20z"/><path d="M187 107h41v42h-41zM198 118v20h19v-20z"/></g></svg>


### PR DESCRIPTION
**Description**

Adds THSND (Thousand) to the token list, Base mainnet only.

- Token: `0xF7aa829ed31fE30834E56348e9CD3fBb4687CFdb` (verified on Basescan)
- Base-native token with no L1 counterpart, so `nobridge: true`
- `name` / `symbol` / `decimals` match on-chain data: Thousand / THSND / 18
- Website: https://thsnd.xyz (logo.svg matches the canonical mark served at https://thsnd.xyz/assets/thsnd-mark-256.png)

**Tests**

Data-only addition (`data/THSND/data.json` + `data/THSND/logo.svg`), no code changes. JSON validated locally.

**Additional context**

One token per PR per the contributing guide.