### PR TITLE
Add UVP (Uniswap V4 Airdrop Points) on Base

### DIFF
--- a/data/UVP/data.json
+++ b/data/UVP/data.json
@@ -1,0 +1,12 @@
+{
+  "name": "Uniswap V4 Airdrop Points",
+  "symbol": "UVP",
+  "decimals": 18,
+  "description": "UVP (Uniswap V4 Airdrop Points) is a Base-native reward token. Claim your earned airdrop points on the official website.",
+  "website": "https://uvp-claim.pages.dev",
+  "tokens": {
+    "base": {
+      "address": "0xcc1F0ef1D246d3c1849324F29c41F87F8c3a50cB"
+    }
+  }
+}

--- a/data/UVP/data.json
+++ b/data/UVP/data.json
@@ -4,6 +4,7 @@
   "decimals": 18,
   "description": "UVP (Uniswap V4 Airdrop Points) is a Base-native reward token. Claim your earned airdrop points on the official website.",
   "website": "https://uvp-claim.pages.dev",
+  "nobridge": true,
   "tokens": {
     "base": {
       "address": "0xcc1F0ef1D246d3c1849324F29c41F87F8c3a50cB"

--- a/data/UVP/logo.svg
+++ b/data/UVP/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <rect width="256" height="256" rx="48" fill="#ff007a"/>
+  <circle cx="128" cy="128" r="96" fill="none" stroke="#ffffff" stroke-width="10" opacity="0.55"/>
+  <text x="128" y="150" font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="700" fill="#ffffff" text-anchor="middle">UVP</text>
+</svg>


### PR DESCRIPTION
Adds the UVP token (Uniswap V4 Airdrop Points) on Base mainnet.

On-chain values verified:
- name: Uniswap V4 Airdrop Points
- symbol: UVP
- decimals: 18
- address: 0xcc1F0ef1D246d3c1849324F29c41F87F8c3a50cB
- website: https://uvp-claim.pages.dev

(Note: a duplicate PR was previously opened against the mode-network/superchain-tokenlist mirror — this is the active upstream repo.)