### PR TITLE
Add Voxel Resonance tokens (SGUIDE, VDOO, PENNIES, PIDX)

### DIFF
--- a/data/base/tokens.json
+++ b/data/base/tokens.json
@@ -1,0 +1,30 @@
+[
+  {
+    "address": "0xa36E026FC453880537e10d21fC139439bD2702fc",
+    "chainId": 8453,
+    "name": "PIDX",
+    "symbol": "PIDX",
+    "decimals": 18
+  },
+  {
+    "address": "0xb50DCEb0570557B9B7FE43D8cBDc9B3457D3dc5a",
+    "chainId": 8453,
+    "name": "Spirit Guide",
+    "symbol": "SGUIDE",
+    "decimals": 18
+  },
+  {
+    "address": "0x38e4f08D08b4D772A7B75669C356b4749dd2d30b",
+    "chainId": 8453,
+    "name": "VDOO Infinity",
+    "symbol": "VDOO",
+    "decimals": 18
+  },
+  {
+    "address": "0x2a92CAA3b01E64634e2E95AA533a5570a76c19A7",
+    "chainId": 8453,
+    "name": "Pennies",
+    "symbol": "PENNIES",
+    "decimals": 18
+  }
+]

--- a/src/data/voudoo_tokens.json
+++ b/src/data/voudoo_tokens.json
@@ -1,0 +1,34 @@
+[
+  {
+    "chainId": 8453,
+    "address": "0x2a92CAA3b01E64634e2E95AA533a5570a76c19A7",
+    "name": "PENNIES CHEQ",
+    "symbol": "PENNIES",
+    "decimals": 18,
+    "logoURI": "https://jvoidial.github.io/spirit-guide-token/images/pennies.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x95c7e2d53f4b615a50d4468dfd5aff850dc17f0c",
+    "name": "Pennies Index",
+    "symbol": "PIDX",
+    "decimals": 18,
+    "logoURI": "https://jvoidial.github.io/spirit-guide-token/images/pidx.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xb50DCEb0570557B9B7FE43D8cBDc9B3457D3dc5a",
+    "name": "SPIRIT GUIDE",
+    "symbol": "SGUIDE",
+    "decimals": 18,
+    "logoURI": "https://jvoidial.github.io/spirit-guide-token/images/sguide.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x38e4f08D08b4D772A7B75669C356b4749dd2d30b",
+    "name": "VOUDOO Infinity",
+    "symbol": "VDOO",
+    "decimals": 18,
+    "logoURI": "https://jvoidial.github.io/spirit-guide-token/images/vdoo.png"
+  }
+]

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -1,0 +1,34 @@
+[
+  {
+    "chainId": 8453,
+    "address": "0x2a92CAA3b01E64634e2E95AA533a5570a76c19A7",
+    "name": "PENNIES CHEQ",
+    "symbol": "✓",
+    "decimals": 18,
+    "logoURI": "https://jvoidial.github.io/spirit-guide-token/images/pennies.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x38e4f08D08b4D772A7B75669C356b4749dd2d30b",
+    "name": "VOUDOO Infinity",
+    "symbol": "VDOO",
+    "decimals": 18,
+    "logoURI": "https://jvoidial.github.io/spirit-guide-token/images/vdoo.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xa36E026FC453880537e10d21fC139439bD2702fc",
+    "name": "Pennies Index",
+    "symbol": "PIDX",
+    "decimals": 18,
+    "logoURI": "https://jvoidial.github.io/spirit-guide-token/images/pidx.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xb50DCEb0570557B9B7FE43D8cBDc9B3457D3dc5a",
+    "name": "SPIRIT GUIDE",
+    "symbol": "SGUIDE",
+    "decimals": 18,
+    "logoURI": "https://jvoidial.github.io/spirit-guide-token/images/sguide.png"
+  }
+]


### PR DESCRIPTION
This PR adds four tokens from the Voxel Resonance ecosystem on Base chain.\n\nAll contracts are verified on BaseScan and Sourcify, ownership renounced, and liquidity is active on Uniswap V2.\n\nToken details:\n- SGUIDE: 0xb50DCEb0570557B9B7FE43D8cBDc9B3457D3dc5a\n- VDOO: 0x38e4f08D08b4D772A7B75669C356b4749dd2d30b\n- PENNIES: 0x2a92CAA3b01E64634e2E95AA533a5570a76c19A7\n- PIDX: 0xa36E026FC453880537e10d21fC139439bD2702fc\n\nEcosystem website: https://jvoidial.github.io/spirit-guide-token/\nSafety report: https://jvoidial.github.io/spirit-guide-token/SAFETY_REPORT.md